### PR TITLE
fix: ignore custom steps without drone enabled in `release` node

### DIFF
--- a/internal/project/common/release.go
+++ b/internal/project/common/release.go
@@ -32,7 +32,7 @@ func NewRelease(meta *meta.Options) *Release {
 func (release *Release) CompileDrone(output *drone.Output) error {
 	output.Step(drone.MakeStep("release-notes").
 		OnlyOnTag().
-		DependsOn(dag.GatherMatchingInputNames(release, dag.Implements((*drone.Compiler)(nil)))...),
+		DependsOn(dag.GatherMatchingInputNames(release, drone.HasDroneOutput())...),
 	)
 
 	output.Step(drone.CustomStep(release.Name()).

--- a/internal/project/custom/custom.go
+++ b/internal/project/custom/custom.go
@@ -80,6 +80,11 @@ func (step *Step) CompileDrone(output *drone.Output) error {
 	return nil
 }
 
+// DroneEnabled implements drone.CustomCompiler.
+func (step *Step) DroneEnabled() bool {
+	return step.Drone.Enabled
+}
+
 // CompileMakefile implements makefile.Compiler.
 func (step *Step) CompileMakefile(output *makefile.Output) error {
 	if !step.Makefile.Enabled {


### PR DESCRIPTION
Otherwise they get added to `dependencies` there and that breaks Drone
builds as these steps are not defined.