### PR TITLE
chore: pin node js version to 14.18.1

### DIFF
--- a/internal/project/js/templates/eslint.yaml
+++ b/internal/project/js/templates/eslint.yaml
@@ -6,3 +6,5 @@ extends:
   - "plugin:vue/vue3-essential"
   - "eslint:recommended"
   - "@vue/typescript"
+rules:
+  no-console: off

--- a/internal/project/js/toolchain.go
+++ b/internal/project/js/toolchain.go
@@ -39,7 +39,7 @@ func NewToolchain(meta *meta.Options, sourceDir string) *Toolchain {
 		meta:      meta,
 		sourceDir: sourceDir,
 
-		Version: "15.14.0-alpine3.13",
+		Version: "14.18.1-alpine3.14",
 	}
 
 	meta.BuildArgs = append(meta.BuildArgs, "JS_TOOLCHAIN")


### PR DESCRIPTION
This is the latest lts version.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>