### PR TITLE
fix: ignore testdata by default in license check

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2021-10-28T19:59:15Z by kres 2ebcde5-dirty.
+# Generated on 2021-10-28T16:28:22Z by kres b8587b7-dirty.
 
 ---
 policies:
@@ -28,6 +28,7 @@ policies:
   spec:
     skipPaths:
       - .git/
+      - testdata/
     includeSuffixes:
       - .go
     excludeSuffixes:

--- a/internal/output/conform/conform.yaml
+++ b/internal/output/conform/conform.yaml
@@ -27,6 +27,7 @@ policies:
   spec:
     skipPaths:
       - .git/
+      - testdata/
     includeSuffixes:
       - .go
     excludeSuffixes:


### PR DESCRIPTION
Testdata is usually not a source code, no need to have license there.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>