### PR TITLE
feat: allow license to be configurable

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2021-09-01T22:12:15Z by kres 5ca7963-dirty.
+# Generated on 2021-10-28T19:59:15Z by kres 2ebcde5-dirty.
 
 ---
 policies:
@@ -33,7 +33,4 @@ policies:
     excludeSuffixes:
       - .pb.go
       - .pb.gw.go
-    header: |
-      // This Source Code Form is subject to the terms of the Mozilla Public
-      // License, v. 2.0. If a copy of the MPL was not distributed with this
-      // file, You can obtain one at http://mozilla.org/MPL/2.0/.
+    header: "// This Source Code Form is subject to the terms of the Mozilla Public\u000A// License, v. 2.0. If a copy of the MPL was not distributed with this\u000A// file, You can obtain one at http://mozilla.org/MPL/2.0/.\u000A"

--- a/internal/output/conform/conform.go
+++ b/internal/output/conform/conform.go
@@ -26,6 +26,7 @@ type Output struct {
 	output.FileAdapter
 
 	githubOrg         string
+	licenseHeader     string
 	scopes            []string
 	types             []string
 	licenseCheck      bool
@@ -72,6 +73,11 @@ func (o *Output) SetTypes(types []string) {
 // SetLicenseCheck enables license check.
 func (o *Output) SetLicenseCheck(enable bool) {
 	o.licenseCheck = enable
+}
+
+// SetLicenseHeader configures license header.
+func (o *Output) SetLicenseHeader(header string) {
+	o.licenseHeader = header
 }
 
 // SetGPGSignatureCheck enables GPG signature check.
@@ -127,6 +133,7 @@ func (o *Output) config(w io.Writer) error {
 		Types                   string
 		Scopes                  string
 		Organization            string
+		LicenseHeader           string
 		EnableLicenseCheck      bool
 		EnableGPGSignatureCheck bool
 	}{
@@ -134,6 +141,7 @@ func (o *Output) config(w io.Writer) error {
 		Scopes:                  string(scopes),
 		Organization:            o.githubOrg,
 		EnableLicenseCheck:      o.licenseCheck,
+		LicenseHeader:           o.licenseHeader,
 		EnableGPGSignatureCheck: o.gpgSignatureCheck,
 	}
 

--- a/internal/output/conform/conform.yaml
+++ b/internal/output/conform/conform.yaml
@@ -32,8 +32,5 @@ policies:
     excludeSuffixes:
       - .pb.go
       - .pb.gw.go
-    header: |
-      // This Source Code Form is subject to the terms of the Mozilla Public
-      // License, v. 2.0. If a copy of the MPL was not distributed with this
-      // file, You can obtain one at http://mozilla.org/MPL/2.0/.
+    header: "{{ .LicenseHeader | js }}"
 {{ end -}}

--- a/internal/output/license/BSL-1.1.txt
+++ b/internal/output/license/BSL-1.1.txt
@@ -1,0 +1,95 @@
+Business Source License 1.1
+
+Parameters
+
+Licensor:             {{ .Licensor }}
+Licensed Work:        {{ .LicensedWork }}
+                      The Licensed Work is {{ .Copyright }}
+Additional Use Grant: None
+
+Change Date:          {{ .ChangeDate }}
+
+Change License:       {{ .ChangeLicense }}
+
+For information about alternative licensing arrangements for the Software,
+please visit: {{ .EnterpriseLink }}
+
+Notice
+
+The Business Source License (this document, or the "License") is not an Open
+Source license. However, the Licensed Work will eventually be made available
+under an Open Source License, as stated in this License.
+
+License text copyright (c) 2017 MariaDB Corporation Ab, All Rights Reserved.
+"Business Source License" is a trademark of MariaDB Corporation Ab.
+
+-----------------------------------------------------------------------------
+
+Business Source License 1.1
+
+Terms
+
+The Licensor hereby grants you the right to copy, modify, create derivative
+works, redistribute, and make non-production use of the Licensed Work. The
+Licensor may make an Additional Use Grant, above, permitting limited
+production use.
+
+Effective on the Change Date, or the fourth anniversary of the first publicly
+available distribution of a specific version of the Licensed Work under this
+License, whichever comes first, the Licensor hereby grants you rights under
+the terms of the Change License, and the rights granted in the paragraph
+above terminate.
+
+If your use of the Licensed Work does not comply with the requirements
+currently in effect as described in this License, you must purchase a
+commercial license from the Licensor, its affiliated entities, or authorized
+resellers, or you must refrain from using the Licensed Work.
+
+All copies of the original and modified Licensed Work, and derivative works
+of the Licensed Work, are subject to this License. This License applies
+separately for each version of the Licensed Work and the Change Date may vary
+for each version of the Licensed Work released by Licensor.
+
+You must conspicuously display this License on each original or modified copy
+of the Licensed Work. If you receive the Licensed Work in original or
+modified form from a third party, the terms and conditions set forth in this
+License apply to your use of that work.
+
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other
+versions of the Licensed Work.
+
+This License does not grant you any right in any trademark or logo of
+Licensor or its affiliates (provided that you may use a trademark or logo of
+Licensor as expressly required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+TITLE.
+
+MariaDB hereby grants you permission to use this License’s text to license
+your works, and to refer to it using the trademark "Business Source License",
+as long as you comply with the Covenants of Licensor below.
+
+Covenants of Licensor
+
+In consideration of the right to use this License’s text and the "Business
+Source License" name and trademark, Licensor covenants to MariaDB, and to all
+other recipients of the licensed work to be provided by Licensor:
+
+1. To specify as the Change License the GPL Version 2.0 or any later version,
+   or a license that is compatible with GPL Version 2.0 or a later version,
+   where "compatible" means that software provided under the Change License can
+   be included in a program with software provided under GPL Version 2.0 or a
+   later version. Licensor may specify additional Change Licenses without
+   limitation.
+
+2. To either: (a) specify an additional grant of rights to use that does not
+   impose any additional restriction on the right granted in this License, as
+   the Additional Use Grant; or (b) insert the text "None".
+
+3. To specify a Change Date.
+
+4. Not to modify this License in any other way.

--- a/internal/output/license/MPL-2.0.txt
+++ b/internal/output/license/MPL-2.0.txt
@@ -1,10 +1,4 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-package license
-
-const mpl20 = `Mozilla Public License Version 2.0
+Mozilla Public License Version 2.0
 ==================================
 
 1. Definitions
@@ -377,4 +371,3 @@ Exhibit B - "Incompatible With Secondary Licenses" Notice
 
   This Source Code Form is "Incompatible With Secondary Licenses", as
   defined by the Mozilla Public License, v. 2.0.
-`


### PR DESCRIPTION
This still keps Kres default to be MPL-2.0, but also allows BSL-1.1
license and custom license header for conform checks.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>