### PR TITLE
chore: update kres to use new org name

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2021-10-28T16:28:22Z by kres b8587b7-dirty.
+# Generated on 2022-03-23T14:52:24Z by kres 137a0e1.
 
 ---
 policies:
@@ -10,7 +10,7 @@ policies:
     gpg:
       required: true
       identity:
-        gitHubOrganization: talos-systems
+        gitHubOrganization: siderolabs
     spellcheck:
       locale: US
     maximumOfOneCommit: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2021-11-07T12:42:33Z by kres latest.
+# Generated on 2022-03-23T14:52:24Z by kres 137a0e1.
 
 ARG TOOLCHAIN
 
@@ -91,6 +91,6 @@ ARG TARGETARCH
 COPY --from=kres kres-linux-${TARGETARCH} /kres
 COPY --from=image-fhs / /
 COPY --from=image-ca-certificates / /
-LABEL org.opencontainers.image.source https://github.com/talos-systems/kres
+LABEL org.opencontainers.image.source https://github.com/siderolabs/kres
 ENTRYPOINT ["/kres","gen"]
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2021-11-07T12:42:33Z by kres latest.
+# Generated on 2022-03-23T14:52:24Z by kres 137a0e1.
 
 # common variables
 
@@ -9,7 +9,7 @@ TAG := $(shell git describe --tag --always --dirty)
 BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 ARTIFACTS := _out
 REGISTRY ?= ghcr.io
-USERNAME ?= talos-systems
+USERNAME ?= siderolabs
 REGISTRY_AND_USERNAME ?= $(REGISTRY)/$(USERNAME)
 GOFUMPT_VERSION ?= abc0db2c416aca0f60ea33c23c76665f6e7ba0b6
 GO_VERSION ?= 1.17


### PR DESCRIPTION
We need to update `.git/config` to change the upstream/origin URL to use
`siderolabs` org and Kres will take care about the rest.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>