### PR TITLE
feat: vtprotobuf bump, protoc aggregation, gofumpt + goimports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2022-03-31T15:16:26Z by kres ff0aee3-dirty.
+# Generated on 2022-04-22T17:27:37Z by kres 685be7b-dirty.
 
 # common variables
 
@@ -11,12 +11,13 @@ ARTIFACTS := _out
 REGISTRY ?= ghcr.io
 USERNAME ?= siderolabs
 REGISTRY_AND_USERNAME ?= $(REGISTRY)/$(USERNAME)
-GOFUMPT_VERSION ?= abc0db2c416aca0f60ea33c23c76665f6e7ba0b6
+GOFUMPT_VERSION ?= v0.3.1
 GO_VERSION ?= 1.18
+GOIMPORTS_VERSION ?= v0.1.10
 PROTOBUF_GO_VERSION ?= 1.28.0
 GRPC_GO_VERSION ?= 1.2.0
 GRPC_GATEWAY_VERSION ?= 2.10.0
-VTPROTOBUF_VERSION ?= d8520340f57329767fd3b2c9cc0aea3703dd68c9
+VTPROTOBUF_VERSION ?= 0.3.0
 TESTPKGS ?= ./...
 KRES_IMAGE ?= ghcr.io/siderolabs/kres:latest
 
@@ -37,6 +38,7 @@ COMMON_ARGS += --build-arg=TAG=$(TAG)
 COMMON_ARGS += --build-arg=USERNAME=$(USERNAME)
 COMMON_ARGS += --build-arg=TOOLCHAIN=$(TOOLCHAIN)
 COMMON_ARGS += --build-arg=GOFUMPT_VERSION=$(GOFUMPT_VERSION)
+COMMON_ARGS += --build-arg=GOIMPORTS_VERSION=$(GOIMPORTS_VERSION)
 COMMON_ARGS += --build-arg=PROTOBUF_GO_VERSION=$(PROTOBUF_GO_VERSION)
 COMMON_ARGS += --build-arg=GRPC_GO_VERSION=$(GRPC_GO_VERSION)
 COMMON_ARGS += --build-arg=GRPC_GATEWAY_VERSION=$(GRPC_GATEWAY_VERSION)
@@ -99,8 +101,11 @@ lint-gofumpt:  ## Runs gofumpt linter.
 fmt:  ## Formats the source code
 	@docker run --rm -it -v $(PWD):/src -w /src golang:$(GO_VERSION) \
 		bash -c "export GO111MODULE=on; export GOPROXY=https://proxy.golang.org; \
-		go install mvdan.cc/gofumpt/gofumports@$(GOFUMPT_VERSION) && \
-		gofumports -w -local github.com/talos-systems/kres ."
+		go install mvdan.cc/gofumpt@$(GOFUMPT_VERSION) && \
+		gofumpt -w ."
+
+lint-goimports:  ## Runs goimports linter.
+	@$(MAKE) target-$@
 
 .PHONY: base
 base:  ## Prepare base toolchain
@@ -133,7 +138,7 @@ lint-markdown:  ## Runs markdownlint.
 	@$(MAKE) target-$@
 
 .PHONY: lint
-lint: lint-golangci-lint lint-gofumpt lint-markdown  ## Run all linters for the project.
+lint: lint-golangci-lint lint-gofumpt lint-goimports lint-markdown  ## Run all linters for the project.
 
 .PHONY: image-kres
 image-kres:  ## Builds image for kres.

--- a/internal/project/auto/golang.go
+++ b/internal/project/auto/golang.go
@@ -142,16 +142,17 @@ func (builder *builder) BuildGolang() error {
 	// linters
 	golangciLint := golang.NewGolangciLint(builder.meta)
 	gofumpt := golang.NewGofumpt(builder.meta)
+	goimports := golang.NewGoimports(builder.meta)
 
 	// linters are input to the toolchain as they inject into toolchain build
-	toolchain.AddInput(golangciLint, gofumpt)
+	toolchain.AddInput(golangciLint, gofumpt, goimports)
 
 	// add protobufs
 	protobuf := golang.NewProtobuf(builder.meta)
 
 	toolchain.AddInput(protobuf)
 
-	builder.lintInputs = append(builder.lintInputs, toolchain, golangciLint, gofumpt)
+	builder.lintInputs = append(builder.lintInputs, toolchain, golangciLint, gofumpt, goimports)
 
 	// unit-tests
 	unitTests := golang.NewUnitTests(builder.meta)

--- a/internal/project/golang/goimports.go
+++ b/internal/project/golang/goimports.go
@@ -1,0 +1,75 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package golang
+
+import (
+	"fmt"
+
+	"github.com/talos-systems/kres/internal/dag"
+	"github.com/talos-systems/kres/internal/output/dockerfile"
+	"github.com/talos-systems/kres/internal/output/dockerfile/step"
+	"github.com/talos-systems/kres/internal/output/makefile"
+	"github.com/talos-systems/kres/internal/project/meta"
+)
+
+// Goimports provides goimports linter.
+type Goimports struct {
+	dag.BaseNode
+
+	meta *meta.Options
+
+	Version string `yaml:"version"`
+}
+
+// NewGoimports builds Goimports node.
+func NewGoimports(meta *meta.Options) *Goimports {
+	meta.BuildArgs = append(meta.BuildArgs, "GOIMPORTS_VERSION")
+
+	return &Goimports{
+		BaseNode: dag.NewBaseNode("lint-goimports"),
+
+		meta: meta,
+
+		Version: "v0.1.10",
+	}
+}
+
+// CompileMakefile implements makefile.Compiler.
+func (lint *Goimports) CompileMakefile(output *makefile.Output) error {
+	output.Target("lint-goimports").Description("Runs goimports linter.").
+		Script("@$(MAKE) target-$@")
+
+	output.VariableGroup(makefile.VariableGroupCommon).
+		Variable(makefile.OverridableVariable("GOIMPORTS_VERSION", lint.Version))
+
+	return nil
+}
+
+// ToolchainBuild implements common.ToolchainBuilder hook.
+func (lint *Goimports) ToolchainBuild(stage *dockerfile.Stage) error {
+	stage.
+		Step(step.Arg("GOIMPORTS_VERSION")).
+		Step(step.Script(fmt.Sprintf(
+			`go install golang.org/x/tools/cmd/goimports@${GOIMPORTS_VERSION} \
+	&& mv /go/bin/goimports %s/goimports`, lint.meta.BinPath)))
+
+	return nil
+}
+
+// CompileDockerfile implements dockerfile.Compiler.
+func (lint *Goimports) CompileDockerfile(output *dockerfile.Output) error {
+	output.Stage("lint-goimports").
+		Description("runs goimports").
+		From("base").
+		Step(step.Script(
+			fmt.Sprintf(
+				`FILES="$(goimports -l -local %s .)" && test -z "${FILES}" || (echo -e "Source code is not formatted with 'goimports -w -local %s .':\n${FILES}"; exit 1)`,
+				lint.meta.CanonicalPath,
+				lint.meta.CanonicalPath,
+			),
+		))
+
+	return nil
+}

--- a/internal/project/golang/goimports_test.go
+++ b/internal/project/golang/goimports_test.go
@@ -1,0 +1,22 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package golang_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/talos-systems/kres/internal/output/dockerfile"
+	"github.com/talos-systems/kres/internal/output/makefile"
+	"github.com/talos-systems/kres/internal/project/common"
+	"github.com/talos-systems/kres/internal/project/golang"
+)
+
+func TestGoimportsInterfaces(t *testing.T) {
+	assert.Implements(t, (*dockerfile.Compiler)(nil), new(golang.Goimports))
+	assert.Implements(t, (*makefile.Compiler)(nil), new(golang.Goimports))
+	assert.Implements(t, (*common.ToolchainBuilder)(nil), new(golang.Goimports))
+}


### PR DESCRIPTION
Fixes #87

This is a bunch of changes:

* update `vtprotobuf` to the release version which fixes some bugs
* update `gofumpt`, as it is missing `gofumports` now, add `goimports`
* generate as many specs as possible in a single `protoc` run, as
otherwise it casuses problem for `vtprotobuf` when all generared files
are going to the same Go package (duplicate declarations)
* format generated protobuf files

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>