### PR TITLE
feat: detect main branch name

### DIFF
--- a/internal/output/drone/step.go
+++ b/internal/output/drone/step.go
@@ -89,9 +89,9 @@ func (step *Step) OnlyOnTag() *Step {
 	return step
 }
 
-// OnlyOnMaster adds condition to run step only on master branch.
-func (step *Step) OnlyOnMaster() *Step {
-	step.container.When.Branch.Include = append(step.container.When.Branch.Include, "master")
+// OnlyOnBranch adds condition to run step only on the specified branch.
+func (step *Step) OnlyOnBranch(branchName string) *Step {
+	step.container.When.Branch.Include = append(step.container.When.Branch.Include, branchName)
 
 	return step
 }

--- a/internal/project/common/image.go
+++ b/internal/project/common/image.go
@@ -66,7 +66,7 @@ func (image *Image) CompileDrone(output *drone.Output) error {
 		output.Step(drone.MakeStep(image.Name(), "TAG=latest").
 			Name(fmt.Sprintf("push-%s-latest", image.ImageName)).
 			Environment("PUSH", "true").
-			OnlyOnMaster().
+			OnlyOnBranch(image.meta.MainBranch).
 			ExceptPullRequest().
 			DockerLogin().
 			DependsOn(fmt.Sprintf("push-%s", image.ImageName)),

--- a/internal/project/common/repository.go
+++ b/internal/project/common/repository.go
@@ -58,7 +58,7 @@ func NewRepository(meta *meta.Options) *Repository {
 
 		meta: meta,
 
-		MainBranch: "master",
+		MainBranch: meta.MainBranch,
 		EnforceContexts: []string{
 			"continuous-integration/drone/pr",
 		},

--- a/internal/project/meta/meta.go
+++ b/internal/project/meta/meta.go
@@ -16,6 +16,9 @@ type Options struct { //nolint:govet
 	GitHubOrganization string
 	GitHubRepository   string
 
+	// Git settings.
+	MainBranch string
+
 	// CanonicalPath, import path for Go projects.
 	CanonicalPath string
 


### PR DESCRIPTION
Previously we defaulted to the main branch name "master". However many projects use "main" or "develop" as their main branch name and we add support by detecting the main branch of the origin remote from .git/config.

Fixes #84

Signed-off-by: Philipp Sauter <philipp.sauter@siderolabs.com>