### PR TITLE
feat: support running go generate

### DIFF
--- a/internal/project/auto/golang.go
+++ b/internal/project/auto/golang.go
@@ -147,13 +147,13 @@ func (builder *builder) BuildGolang() error {
 	// linters are input to the toolchain as they inject into toolchain build
 	toolchain.AddInput(golangciLint, gofumpt, goimports)
 
-	// add protobufs
-	protobuf := golang.NewProtobuf(builder.meta)
+	// add protobufs and go generate
+	generate := golang.NewGenerate(builder.meta)
 
 	// add deepcopy
 	deepcopy := golang.NewDeepCopy(builder.meta)
 
-	toolchain.AddInput(protobuf, deepcopy)
+	toolchain.AddInput(generate, deepcopy)
 
 	builder.lintInputs = append(builder.lintInputs, toolchain, golangciLint, gofumpt, goimports)
 

--- a/internal/project/common/repository.go
+++ b/internal/project/common/repository.go
@@ -117,6 +117,8 @@ func (r *Repository) CompileLicense(o *license.Output) error {
 		return nil
 	}
 
+	o.SetLicenseHeader(r.License.Header)
+
 	return o.Enable(r.License.ID, r.License.Params)
 }
 


### PR DESCRIPTION
The `golang.Protobuf` step was renamed to `golang.Generate`. The
projects using `golang.Protobuf` should get the config update.

Generator can be configured by the following section:

```yaml
...
golang.Generate:
  goGenerateSpecs:
    - source: ./ # the root folder of the project
      copy:
        # folders with the files containing go generate definitions
        # can be root folder, but it's better to specify only specific
        # folders for better performance
        - internal/app/
```

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>