### PR TITLE
feat: allow to specify external for proto file explicitly

### DIFF
--- a/internal/project/golang/generate.go
+++ b/internal/project/golang/generate.go
@@ -43,6 +43,7 @@ type Generate struct {
 // ProtoSpec describes a set of protobuf specs to be compiled.
 type ProtoSpec struct {
 	Source       string `yaml:"source"`
+	External     *bool  `yaml:"external"`
 	SubDirectory string `yaml:"subdirectory"`
 
 	sourcePath string
@@ -146,7 +147,9 @@ func (generate *Generate) CompileDockerfile(output *dockerfile.Output) error {
 		}
 
 		for i := range generate.Specs {
-			if strings.HasPrefix(generate.Specs[i].Source, "http") {
+			if generate.Specs[i].External != nil {
+				generate.Specs[i].external = *generate.Specs[i].External
+			} else if strings.HasPrefix(generate.Specs[i].Source, "http") {
 				generate.Specs[i].external = true
 			}
 


### PR DESCRIPTION
COSI has "external" specs, but they're internal as they live in the same
package. This fixes gRPC-Gateway generation for COSI.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>