### PR TITLE
fix: disable `ireturn` linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2022-05-21T09:35:58Z by kres 48670a1-dirty.
+# Generated on 2022-06-28T12:54:11Z by kres ba905fc-dirty.
 
 # options for analysis running
 run:
@@ -135,6 +135,7 @@ linters:
     - goerr113
     - gomnd
     - gomoddirectives
+    - ireturn
     - nestif
     - paralleltest
     - tagliatelle

--- a/internal/output/golangci/golangci.yml
+++ b/internal/output/golangci/golangci.yml
@@ -131,6 +131,7 @@ linters:
     - goerr113
     - gomnd
     - gomoddirectives
+    - ireturn
     - nestif
     - paralleltest
     - tagliatelle


### PR DESCRIPTION
This linter is not really useful, and has lots of false alerts when
using the Go cache.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>