### PR TITLE
chore: bump base node to v18.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,19 +2,19 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2022-05-21T09:58:34Z by kres 48670a1-dirty.
+# Generated on 2022-06-30T20:40:35Z by kres 80891cd-dirty.
 
 ARG TOOLCHAIN
 
 # cleaned up specs and compiled versions
 FROM scratch AS generate
 
-FROM ghcr.io/siderolabs/ca-certificates:v1.0.0 AS image-ca-certificates
+FROM ghcr.io/siderolabs/ca-certificates:v1.1.0 AS image-ca-certificates
 
-FROM ghcr.io/siderolabs/fhs:v1.0.0 AS image-fhs
+FROM ghcr.io/siderolabs/fhs:v1.1.0 AS image-fhs
 
 # runs markdownlint
-FROM node:18.2.0-alpine AS lint-markdown
+FROM node:18.4.0-alpine AS lint-markdown
 WORKDIR /src
 RUN npm i -g markdownlint-cli@0.31.1
 RUN npm i sentences-per-line@0.2.1

--- a/internal/project/common/input_image.go
+++ b/internal/project/common/input_image.go
@@ -34,7 +34,7 @@ func NewFHS(meta *meta.Options) *InputImage {
 		BaseNode: dag.NewBaseNode(fmt.Sprintf("image-%s", "fhs")),
 
 		Image:   "ghcr.io/siderolabs/fhs",
-		Version: "v1.0.0",
+		Version: "v1.1.0",
 	}
 }
 
@@ -44,6 +44,6 @@ func NewCACerts(meta *meta.Options) *InputImage {
 		BaseNode: dag.NewBaseNode(fmt.Sprintf("image-%s", "ca-certificates")),
 
 		Image:   "ghcr.io/siderolabs/ca-certificates",
-		Version: "v1.0.0",
+		Version: "v1.1.0",
 	}
 }

--- a/internal/project/js/eslint.go
+++ b/internal/project/js/eslint.go
@@ -23,7 +23,7 @@ type EsLint struct {
 
 // NewEsLint builds golangci-lint node.
 func NewEsLint(meta *meta.Options) *EsLint {
-	meta.SourceFiles = append(meta.SourceFiles, ".eslintrc.yaml")
+	meta.SourceFiles = append(meta.SourceFiles, "frontend/.eslintrc.yaml")
 
 	return &EsLint{
 		BaseNode: dag.NewBaseNode("lint-eslint"),
@@ -34,7 +34,7 @@ func NewEsLint(meta *meta.Options) *EsLint {
 
 // CompileTemplates implements templates.Compiler.
 func (lint *EsLint) CompileTemplates(output *template.Output) error {
-	output.Define(".eslintrc.yaml", templates.Eslint).
+	output.Define("frontend/.eslintrc.yaml", templates.Eslint).
 		PreamblePrefix("# ")
 
 	return nil

--- a/internal/project/js/protobuf.go
+++ b/internal/project/js/protobuf.go
@@ -53,8 +53,8 @@ func NewProtobuf(meta *meta.Options, name string) *Protobuf {
 
 		meta: meta,
 
-		ProtobufTSVersion:        "v1.79.2",
-		ProtobufTSGatewayVersion: "v1.1.0",
+		ProtobufTSVersion:        "v1.115.5",
+		ProtobufTSGatewayVersion: "v1.1.2",
 
 		BaseSpecPath: "/api",
 	}

--- a/internal/project/js/toolchain.go
+++ b/internal/project/js/toolchain.go
@@ -40,7 +40,7 @@ func NewToolchain(meta *meta.Options, sourceDir string) *Toolchain {
 		meta:      meta,
 		sourceDir: sourceDir,
 
-		Version: "14.18.1-alpine3.14",
+		Version: "18.4.0-alpine3.16",
 	}
 
 	meta.BuildArgs = append(meta.BuildArgs, "JS_TOOLCHAIN")
@@ -140,7 +140,7 @@ func (toolchain *Toolchain) CompileDockerfile(output *dockerfile.Output) error {
 			MountCache(toolchain.meta.NpmCachePath)).
 		Step(step.Script("npm install").
 			MountCache(toolchain.meta.NpmCachePath)).
-		Step(step.Copy(".eslintrc.yaml", "./")).
+		Step(step.Copy("frontend/.eslintrc.yaml", "./")).
 		Step(step.Copy(filepath.Join(toolchain.sourceDir, "babel.config.js"), "./")).
 		Step(step.Copy(filepath.Join(toolchain.sourceDir, "jest.config.js"), "./")).
 		Step(step.Copy(filepath.Join(toolchain.sourceDir, "tsconfig.json"), "./"))

--- a/internal/project/markdown/lint.go
+++ b/internal/project/markdown/lint.go
@@ -35,7 +35,7 @@ func NewLint(meta *meta.Options) *Lint {
 
 		meta: meta,
 
-		BaseImage:               "node:18.2.0-alpine",
+		BaseImage:               "node:18.4.0-alpine",
 		MardownLintCLIVersion:   "0.31.1",
 		SentencesPerLineVersion: "0.2.1",
 	}


### PR DESCRIPTION
Bump base node version to v18.4.0
Also bump ts-proto and protoc-gen-grpc-gateway-ts

Signed-off-by: Noel Georgi <git@frezbo.dev>