### PR TITLE
chore: ignore docker patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,5 +15,8 @@ updates:
       day: "monday"
       time: "01:00"
       timezone: "UTC"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
 
 # no website for now


### PR DESCRIPTION
Ignore dependabot updates for patch tags of docker deps

Signed-off-by: Noel Georgi <git@frezbo.dev>