### PR TITLE
feat: allow resource requests for custom Drone steps

### DIFF
--- a/internal/output/drone/step.go
+++ b/internal/output/drone/step.go
@@ -135,6 +135,22 @@ func (step *Step) Image(image string) *Step {
 	return step
 }
 
+// ResourceRequests sets step resource requests.
+func (step *Step) ResourceRequests(cpuCores, memoryGib int) *Step {
+	if step.container.Resources == nil {
+		step.container.Resources = &yaml.Resources{}
+	}
+
+	if step.container.Resources.Requests == nil {
+		step.container.Resources.Requests = &yaml.ResourceObject{}
+	}
+
+	step.container.Resources.Requests.CPU = float64(cpuCores) * 1000.0
+	step.container.Resources.Requests.Memory = yaml.BytesSize(int64(memoryGib) * 1024 * 1024 * 1024)
+
+	return step
+}
+
 // PublishArtifacts publishes artifacts with the default Github settings.
 func (step *Step) PublishArtifacts(note string, artifacts ...string) *Step {
 	step.container.Settings = map[string]*yaml.Parameter{

--- a/internal/project/custom/custom.go
+++ b/internal/project/custom/custom.go
@@ -14,6 +14,8 @@ import (
 )
 
 // Step is defined in the config manually.
+//
+//nolint:govet
 type Step struct {
 	dag.BaseNode
 
@@ -34,6 +36,10 @@ type Step struct {
 	Drone struct {
 		Enabled    bool `yaml:"enabled"`
 		Privileged bool `yaml:"privileged"`
+		Requests   *struct {
+			CPUCores  int `yaml:"cpuCores"`
+			MemoryGiB int `yaml:"memoryGiB"`
+		} `yaml:"requests"`
 	} `yaml:"drone"`
 }
 
@@ -73,6 +79,10 @@ func (step *Step) CompileDrone(output *drone.Output) error {
 
 	if step.Drone.Privileged {
 		droneStep.Privileged()
+	}
+
+	if step.Drone.Requests != nil {
+		droneStep.ResourceRequests(step.Drone.Requests.CPUCores, step.Drone.Requests.MemoryGiB)
 	}
 
 	output.Step(droneStep)


### PR DESCRIPTION
This is needed when we run huge workloads in the integration tests.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>