### PR TITLE
fix: add an option to ts-proto generator which fixes JS compilation

### DIFF
--- a/internal/project/js/protobuf.go
+++ b/internal/project/js/protobuf.go
@@ -152,6 +152,7 @@ func (proto *Protobuf) CompileDockerfile(output *dockerfile.Output) error {
 			"--ts_proto_opt=returnObservable=false",
 			"--ts_proto_opt=outputClientImpl=false",
 			"--ts_proto_opt=snakeToCamel=false",
+			"--ts_proto_opt=esModuleInterop=true",
 		)
 
 		args = append(args, proto.ExperimentalFlags...)


### PR DESCRIPTION
Without the option it imports `Long` type incorrectly which renders
generated files unusable in the web based TypeScript.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>