### PR TITLE
chore: bump node to v18.6.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2022-07-07T20:26:55Z by kres 4d1c8c7-dirty.
+# Generated on 2022-07-14T05:58:00Z by kres e2f718d-dirty.
 
 ARG TOOLCHAIN
 
@@ -14,7 +14,7 @@ FROM ghcr.io/siderolabs/ca-certificates:v1.1.0 AS image-ca-certificates
 FROM ghcr.io/siderolabs/fhs:v1.1.0 AS image-fhs
 
 # runs markdownlint
-FROM node:18.5.0-alpine AS lint-markdown
+FROM node:18.6.0-alpine AS lint-markdown
 WORKDIR /src
 RUN npm i -g markdownlint-cli@0.31.1
 RUN npm i sentences-per-line@0.2.1

--- a/internal/project/js/toolchain.go
+++ b/internal/project/js/toolchain.go
@@ -40,7 +40,7 @@ func NewToolchain(meta *meta.Options, sourceDir string) *Toolchain {
 		meta:      meta,
 		sourceDir: sourceDir,
 
-		Version: "18.5.0-alpine3.16",
+		Version: "18.6.0-alpine3.16",
 	}
 
 	meta.BuildArgs = append(meta.BuildArgs, "JS_TOOLCHAIN")

--- a/internal/project/markdown/lint.go
+++ b/internal/project/markdown/lint.go
@@ -35,7 +35,7 @@ func NewLint(meta *meta.Options) *Lint {
 
 		meta: meta,
 
-		BaseImage:               "node:18.5.0-alpine",
+		BaseImage:               "node:18.6.0-alpine",
 		MardownLintCLIVersion:   "0.31.1",
 		SentencesPerLineVersion: "0.2.1",
 	}


### PR DESCRIPTION
Bump Node to v18.6.0

Signed-off-by: Noel Georgi <git@frezbo.dev>