### PR TITLE
chore: add `REGISTRY` to build args

### DIFF
--- a/internal/project/common/docker.go
+++ b/internal/project/common/docker.go
@@ -31,7 +31,7 @@ type Docker struct { //nolint:govet
 
 // NewDocker initializes Docker.
 func NewDocker(meta *meta.Options) *Docker {
-	meta.BuildArgs = append(meta.BuildArgs, "USERNAME")
+	meta.BuildArgs = append(meta.BuildArgs, "USERNAME", "REGISTRY")
 
 	return &Docker{
 		BaseNode: dag.NewBaseNode("setup-ci"),


### PR DESCRIPTION
Add `REGISTRY` variable to build args.

Signed-off-by: Noel Georgi <git@frezbo.dev>