### PR TITLE
chore: support overriding target platform

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,7 +1,7 @@
 ---
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2022-05-06T12:28:53Z by kres dbed153.
+# Generated on 2022-09-02T14:30:06Z by kres 268c85d-dirty.
 
 kind: pipeline
 type: kubernetes
@@ -169,6 +169,7 @@ steps:
       from_secret: ghcr_token
     GHCR_USERNAME:
       from_secret: ghcr_username
+    PLATFORM: linux/amd64/linux/arm64
     PUSH: true
   volumes:
   - name: outer-docker-socket

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2022-08-24T14:23:21Z by kres a4dd5df-dirty.
+# Generated on 2022-09-02T07:24:52Z by kres ec2cd64-dirty.
 
 # common variables
 
@@ -39,6 +39,7 @@ COMMON_ARGS += --build-arg=ARTIFACTS=$(ARTIFACTS)
 COMMON_ARGS += --build-arg=SHA=$(SHA)
 COMMON_ARGS += --build-arg=TAG=$(TAG)
 COMMON_ARGS += --build-arg=USERNAME=$(USERNAME)
+COMMON_ARGS += --build-arg=REGISTRY=$(REGISTRY)
 COMMON_ARGS += --build-arg=TOOLCHAIN=$(TOOLCHAIN)
 COMMON_ARGS += --build-arg=GOLANGCILINT_VERSION=$(GOLANGCILINT_VERSION)
 COMMON_ARGS += --build-arg=GOFUMPT_VERSION=$(GOFUMPT_VERSION)

--- a/internal/project/common/docker.go
+++ b/internal/project/common/docker.go
@@ -25,6 +25,7 @@ type Docker struct { //nolint:govet
 
 	DockerImage   string `yaml:"dockerImage"`
 	AllowInsecure bool   `yaml:"allowInsecure"`
+	Platform      string `yaml:"platform"`
 
 	DockerResourceRequests *yaml.ResourceObject `yaml:"dockerResourceRequests"`
 }
@@ -39,6 +40,7 @@ func NewDocker(meta *meta.Options) *Docker {
 		meta: meta,
 
 		DockerImage: fmt.Sprintf("docker:%s", config.DindContainerImageVersion),
+		Platform:    "linux/amd64",
 	}
 }
 
@@ -111,7 +113,7 @@ func (docker *Docker) CompileMakefile(output *makefile.Output) error {
 
 	output.VariableGroup(makefile.VariableGroupDocker).
 		Variable(makefile.SimpleVariable("BUILD", "docker buildx build")).
-		Variable(makefile.OverridableVariable("PLATFORM", "linux/amd64")).
+		Variable(makefile.OverridableVariable("PLATFORM", docker.Platform)).
 		Variable(makefile.OverridableVariable("PROGRESS", "auto")).
 		Variable(makefile.OverridableVariable("PUSH", "false")).
 		Variable(makefile.OverridableVariable("CI_ARGS", "")).

--- a/internal/project/common/image.go
+++ b/internal/project/common/image.go
@@ -57,6 +57,7 @@ func (image *Image) CompileDrone(output *drone.Output) error {
 	output.Step(drone.MakeStep(image.Name()).
 		Name(fmt.Sprintf("push-%s", image.ImageName)).
 		Environment("PUSH", "true").
+		Environment("PLATFORM", "linux/amd64/linux/arm64").
 		ExceptPullRequest().
 		DockerLogin().
 		DependsOn(image.Name()),


### PR DESCRIPTION
Support overriding target platform.

Eg:

```yaml
---
kind: common.Docker
name: setup-ci
spec:
  platform: linux/amd64,linux/arm64
```

Signed-off-by: Noel Georgi <git@frezbo.dev>