### PR TITLE
chore: support go cross builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2022-08-29T14:47:43Z by kres bb965bb.
+# Generated on 2022-09-02T18:00:52Z by kres be07ec3-dirty.
 
 ARG TOOLCHAIN
 
@@ -27,7 +27,7 @@ FROM ${TOOLCHAIN} AS toolchain
 RUN apk --update --no-cache add bash curl build-base protoc protobuf-dev
 
 # build tools
-FROM toolchain AS tools
+FROM --platform=${BUILDPLATFORM} toolchain AS tools
 ENV GO111MODULE on
 ENV CGO_ENABLED 0
 ENV GOPATH /go

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2022-08-24T14:23:21Z by kres a4dd5df-dirty.
+# Generated on 2022-09-02T17:49:40Z by kres ec2cd64-dirty.
 
 # common variables
 
@@ -39,6 +39,7 @@ COMMON_ARGS += --build-arg=ARTIFACTS=$(ARTIFACTS)
 COMMON_ARGS += --build-arg=SHA=$(SHA)
 COMMON_ARGS += --build-arg=TAG=$(TAG)
 COMMON_ARGS += --build-arg=USERNAME=$(USERNAME)
+COMMON_ARGS += --build-arg=REGISTRY=$(REGISTRY)
 COMMON_ARGS += --build-arg=TOOLCHAIN=$(TOOLCHAIN)
 COMMON_ARGS += --build-arg=GOLANGCILINT_VERSION=$(GOLANGCILINT_VERSION)
 COMMON_ARGS += --build-arg=GOFUMPT_VERSION=$(GOFUMPT_VERSION)

--- a/internal/project/golang/toolchain.go
+++ b/internal/project/golang/toolchain.go
@@ -136,7 +136,7 @@ func (toolchain *Toolchain) CompileDockerfile(output *dockerfile.Output) error {
 
 	tools := output.Stage("tools").
 		Description("build tools").
-		From("toolchain").
+		From("--platform=${BUILDPLATFORM} toolchain").
 		Step(step.Env("GO111MODULE", "on")).
 		Step(step.Env("CGO_ENABLED", "0")).
 		Step(step.Env("GOPATH", toolchain.meta.GoPath))


### PR DESCRIPTION
Support building cross platform go binaries.
Suport setting custom drone Environment for images.

Eg:

```yaml
---
kind: common.Image
name: image-<app>
spec:
  pushLatest: false
  droneExtraEnvironment:
    PLATFORM: linux/amd64,linux/arm64
---
kind: golang.Build
spec:
  outputs:
    linux-amd64:
      GOOS: linux
      GOARCH: amd64
    linux-arm64:
      GOOS: linux
      GOARCH: arm64
```

Signed-off-by: Noel Georgi <git@frezbo.dev>