### PR TITLE
chore: disable drone slack pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,7 +1,7 @@
 ---
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2022-09-15T14:02:10Z by kres 235eb9f-dirty.
+# Generated on 2022-09-19T13:04:40Z by kres 79beef9-dirty.
 
 kind: pipeline
 type: kubernetes
@@ -336,9 +336,10 @@ steps:
     - failure
 
 trigger:
-  status:
-  - success
-  - failure
+  branch:
+    exclude:
+    - renovate/*
+    - dependabot/*
 
 depends_on:
 - default

--- a/internal/output/drone/drone.go
+++ b/internal/output/drone/drone.go
@@ -73,8 +73,11 @@ func NewOutput() *Output {
 			Disable: true,
 		},
 		Trigger: yaml.Conditions{
-			Status: yaml.Condition{
-				Include: []string{"success", "failure"},
+			Branch: yaml.Condition{
+				Exclude: []string{
+					"renovate/*",
+					"dependabot/*",
+				},
 			},
 		},
 		Steps: []*yaml.Container{


### PR DESCRIPTION
The slack trigger was already having status set in the step itself, so
remove that and only use the trigger. Follow up of https://github.com/siderolabs/kres/pull/161#issuecomment-1248157563

Signed-off-by: Noel Georgi <git@frezbo.dev>