### PR TITLE
chore: disable drone slack pipeline for renovate

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,7 +1,7 @@
 ---
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2022-09-19T15:28:23Z by kres 9ea8a33-dirty.
+# Generated on 2022-09-19T17:02:13Z by kres 25b304e-dirty.
 
 kind: pipeline
 type: kubernetes
@@ -308,9 +308,6 @@ trigger:
     exclude:
     - renovate/*
     - dependabot/*
-  status:
-  - success
-  - failure
 
 ---
 kind: pipeline
@@ -343,6 +340,9 @@ trigger:
     exclude:
     - renovate/*
     - dependabot/*
+  status:
+  - success
+  - failure
 
 depends_on:
 - default

--- a/internal/output/drone/drone.go
+++ b/internal/output/drone/drone.go
@@ -57,9 +57,6 @@ func NewOutput() *Output {
 	}
 
 	output.defaultPipeline.Trigger = yaml.Conditions{
-		Status: yaml.Condition{
-			Include: []string{"success", "failure"},
-		},
 		Branch: yaml.Condition{
 			Exclude: []string{
 				"renovate/*",
@@ -76,6 +73,9 @@ func NewOutput() *Output {
 			Disable: true,
 		},
 		Trigger: yaml.Conditions{
+			Status: yaml.Condition{
+				Include: []string{"success", "failure"},
+			},
 			Branch: yaml.Condition{
 				Exclude: []string{
 					"renovate/*",


### PR DESCRIPTION
The slack trigger was already having status set in the step itself, so remove that and only use the trigger.

Previous PR #163 set it at the wrong level :facepalm

Signed-off-by: Noel Georgi <git@frezbo.dev>