### PR TITLE
fix: allow Go non-standard layouts

### DIFF
--- a/internal/project/auto/golang.go
+++ b/internal/project/auto/golang.go
@@ -98,7 +98,7 @@ func (builder *builder) DetectGolang() (bool, error) {
 		}
 	}
 
-	if len(builder.meta.GoSourceFiles) == 0 {
+	if len(builder.meta.GoSourceFiles) == 0 && len(builder.meta.GoDirectories) == 0 {
 		return false, fmt.Errorf("no Go source files found")
 	}
 


### PR DESCRIPTION
Allow go files to be absent from the root directory.

Signed-off-by: Dmitriy Matrenichev <dmitry.matrenichev@siderolabs.com>