### PR TITLE
fix: reformat comment on frontend.go to pass linters

### DIFF
--- a/internal/project/js/templates/templates.go
+++ b/internal/project/js/templates/templates.go
@@ -36,6 +36,7 @@ var GoEmbed = `package {{.project}}
 import "embed"
 
 // Dist is an embedded JS frontend release folder.
+//
 //go:embed dist
 var Dist embed.FS
 `


### PR DESCRIPTION
Reformat the comment to be gofmt 1.19 compatible, so it doesn't fail on linting.

Signed-off-by: Utku Ozdemir <utku.ozdemir@siderolabs.com>