### PR TITLE
feat: add `WITH_DEBUG` arg to enable debug build tag

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,7 +1,7 @@
 ---
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2022-09-19T17:02:13Z by kres 25b304e-dirty.
+# Generated on 2022-10-04T16:32:38Z by kres fe71103-dirty.
 
 kind: pipeline
 type: kubernetes

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2022-09-27T14:26:26Z by kres 8e6d786-dirty.
+# Generated on 2022-10-04T16:32:38Z by kres fe71103-dirty.
 
 ARG TOOLCHAIN
 
@@ -61,10 +61,11 @@ RUN --mount=type=cache,target=/go/pkg go list -mod=readonly all >/dev/null
 FROM base AS kres-linux-amd64-build
 COPY --from=generate / /
 WORKDIR /src/cmd/kres
+ARG WITH_DEBUG
 ARG VERSION_PKG="github.com/siderolabs/kres/internal/version"
 ARG SHA
 ARG TAG
-RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg go build -ldflags "-s -w -X ${VERSION_PKG}.Name=kres -X ${VERSION_PKG}.SHA=${SHA} -X ${VERSION_PKG}.Tag=${TAG}" -o /kres-linux-amd64
+RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg go build $([ "$WITH_DEBUG" == true ] && echo "-tags sidero.debug" || echo "") -ldflags "-s -w -X ${VERSION_PKG}.Name=kres -X ${VERSION_PKG}.SHA=${SHA} -X ${VERSION_PKG}.Tag=${TAG}" -o /kres-linux-amd64
 
 # runs gofumpt
 FROM base AS lint-gofumpt

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2022-09-27T14:21:38Z by kres 8e6d786-dirty.
+# Generated on 2022-10-04T16:32:38Z by kres fe71103-dirty.
 
 # common variables
 
@@ -21,6 +21,7 @@ GRPC_GATEWAY_VERSION ?= 2.11.3
 VTPROTOBUF_VERSION ?= 0.3.0
 DEEPCOPY_VERSION ?= v0.5.5
 TESTPKGS ?= ./...
+WITH_DEBUG ?= false
 KRES_IMAGE ?= ghcr.io/siderolabs/kres:latest
 CONFORMANCE_IMAGE ?= ghcr.io/siderolabs/conform:latest
 
@@ -50,6 +51,7 @@ COMMON_ARGS += --build-arg=GRPC_GATEWAY_VERSION=$(GRPC_GATEWAY_VERSION)
 COMMON_ARGS += --build-arg=VTPROTOBUF_VERSION=$(VTPROTOBUF_VERSION)
 COMMON_ARGS += --build-arg=DEEPCOPY_VERSION=$(DEEPCOPY_VERSION)
 COMMON_ARGS += --build-arg=TESTPKGS=$(TESTPKGS)
+COMMON_ARGS += --build-arg=WITH_DEBUG=$(WITH_DEBUG)
 TOOLCHAIN ?= docker.io/golang:1.19-alpine
 
 # help menu

--- a/internal/output/dockerfile/step/arg.go
+++ b/internal/output/dockerfile/step/arg.go
@@ -14,7 +14,7 @@ type ArgStep struct {
 	arg string
 }
 
-// Arg creates new AregStep.
+// Arg creates new ArgStep.
 func Arg(arg string) *ArgStep {
 	return &ArgStep{
 		arg: arg,

--- a/internal/project/auto/golang.go
+++ b/internal/project/auto/golang.go
@@ -173,6 +173,8 @@ func (builder *builder) BuildGolang() error {
 
 	builder.targets = append(builder.targets, unitTests, coverage)
 
+	withDebug := golang.NewWithDebug(builder.meta)
+
 	// process commands
 	for _, cmd := range builder.meta.Commands {
 		cfg := CommandConfig{NamedConfig: NamedConfig{name: cmd}}
@@ -182,6 +184,7 @@ func (builder *builder) BuildGolang() error {
 
 		build := golang.NewBuild(builder.meta, cmd, filepath.Join("cmd", cmd))
 		build.AddInput(toolchain)
+		build.AddInput(withDebug)
 		builder.targets = append(builder.targets, build)
 
 		if !cfg.DisableImage {

--- a/internal/project/golang/with_debug.go
+++ b/internal/project/golang/with_debug.go
@@ -1,0 +1,34 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package golang
+
+import (
+	"github.com/siderolabs/kres/internal/dag"
+	"github.com/siderolabs/kres/internal/output/makefile"
+	"github.com/siderolabs/kres/internal/project/meta"
+)
+
+// WithDebugVarName is the variable name for enabling debug mode by adding the special build tag "sidero.debug".
+const WithDebugVarName = "WITH_DEBUG"
+
+// WithDebug is the node which adds the special build tag "sidero.debug" to the build.
+type WithDebug struct {
+	dag.BaseNode
+}
+
+// NewWithDebug creates a new WithDebug node.
+func NewWithDebug(meta *meta.Options) *WithDebug {
+	meta.BuildArgs = append(meta.BuildArgs, WithDebugVarName)
+
+	return &WithDebug{}
+}
+
+// CompileMakefile implements makefile.Compiler.
+func (build *WithDebug) CompileMakefile(output *makefile.Output) error {
+	output.VariableGroup(makefile.VariableGroupCommon).
+		Variable(makefile.OverridableVariable(WithDebugVarName, "false"))
+
+	return nil
+}

--- a/internal/project/golang/with_debug_test.go
+++ b/internal/project/golang/with_debug_test.go
@@ -1,0 +1,18 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package golang_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/siderolabs/kres/internal/output/makefile"
+	"github.com/siderolabs/kres/internal/project/golang"
+)
+
+func TestWithDebugInterfaces(t *testing.T) {
+	assert.Implements(t, (*makefile.Compiler)(nil), new(golang.WithDebug))
+}


### PR DESCRIPTION
Add the `WITH_DEBUG` arg which passes `-tags sidero.debug` to the go builds.

Part of siderolabs/kres#88.

Signed-off-by: Utku Ozdemir <utku.ozdemir@siderolabs.com>