### PR TITLE
refactor: dag.Implements not to use reflect package

### DIFF
--- a/internal/dag/node.go
+++ b/internal/dag/node.go
@@ -4,10 +4,6 @@
 
 package dag
 
-import (
-	"reflect"
-)
-
 // Node in directed acyclic graph, recording parent nodes as inputs.
 type Node interface {
 	Name() string
@@ -19,12 +15,12 @@ type Node interface {
 // NodeCondition checks the node for a specific condition.
 type NodeCondition func(Node) bool
 
-// Implements checks whether node implements specific interface.
+// Implements checks whether node implements specific type T.
 func Implements[T any]() NodeCondition {
 	return func(node Node) bool {
-		var t T
+		_, ok := node.(T)
 
-		return reflect.TypeOf(node).Implements(reflect.TypeOf(t).Elem())
+		return ok
 	}
 }
 

--- a/internal/output/drone/drone.go
+++ b/internal/output/drone/drone.go
@@ -196,7 +196,7 @@ type CustomCompiler interface {
 // HasDroneOutput checks if the node implements Compiler and has any output from drone.
 func HasDroneOutput() dag.NodeCondition {
 	return func(node dag.Node) bool {
-		if !dag.Implements[*Compiler]()(node) {
+		if !dag.Implements[Compiler]()(node) {
 			return false
 		}
 

--- a/internal/project/common/all.go
+++ b/internal/project/common/all.go
@@ -29,7 +29,7 @@ func NewAll(meta *meta.Options) *All {
 // CompileMakefile implements makefile.Compiler.
 func (all *All) CompileMakefile(output *makefile.Output) error {
 	output.Target("all").
-		Depends(dag.GatherMatchingInputNames(all, dag.Not(dag.Implements[*makefile.SkipAsMakefileDependency]()))...)
+		Depends(dag.GatherMatchingInputNames(all, dag.Not(dag.Implements[makefile.SkipAsMakefileDependency]()))...)
 
 	return nil
 }

--- a/internal/project/common/image.go
+++ b/internal/project/common/image.go
@@ -52,7 +52,7 @@ func NewImage(meta *meta.Options, name string) *Image {
 // CompileDrone implements drone.Compiler.
 func (image *Image) CompileDrone(output *drone.Output) error {
 	output.Step(drone.MakeStep(image.Name()).
-		DependsOn(dag.GatherMatchingInputNames(image, dag.Implements[*drone.Compiler]())...),
+		DependsOn(dag.GatherMatchingInputNames(image, dag.Implements[drone.Compiler]())...),
 	)
 
 	step := drone.MakeStep(image.Name()).
@@ -114,7 +114,7 @@ func (image *Image) CompileDockerfile(output *dockerfile.Output) error {
 		stage.Step(step.Script(command))
 	}
 
-	inputs := dag.GatherMatchingInputs(image, dag.Implements[*dockerfile.Compiler]())
+	inputs := dag.GatherMatchingInputs(image, dag.Implements[dockerfile.Compiler]())
 	if len(inputs) == 0 {
 		return fmt.Errorf("no inputs for Image block")
 	}

--- a/internal/project/common/lint.go
+++ b/internal/project/common/lint.go
@@ -30,7 +30,7 @@ func NewLint(meta *meta.Options) *Lint {
 // CompileDrone implements drone.Compiler.
 func (lint *Lint) CompileDrone(output *drone.Output) error {
 	output.Step(drone.MakeStep("lint").
-		DependsOn(dag.GatherMatchingInputNames(lint, dag.Implements[*drone.Compiler]())...),
+		DependsOn(dag.GatherMatchingInputNames(lint, dag.Implements[drone.Compiler]())...),
 	)
 
 	return nil
@@ -39,7 +39,7 @@ func (lint *Lint) CompileDrone(output *drone.Output) error {
 // CompileMakefile implements makefile.Compiler.
 func (lint *Lint) CompileMakefile(output *makefile.Output) error {
 	output.Target("lint").Description("Run all linters for the project.").
-		Depends(dag.GatherMatchingInputNames(lint, dag.Not(dag.Implements[*makefile.SkipAsMakefileDependency]()))...).
+		Depends(dag.GatherMatchingInputNames(lint, dag.Not(dag.Implements[makefile.SkipAsMakefileDependency]()))...).
 		Phony()
 
 	return nil

--- a/internal/project/custom/custom.go
+++ b/internal/project/custom/custom.go
@@ -122,7 +122,7 @@ func (step *Step) CompileDrone(output *drone.Output) error {
 	}
 
 	droneMatches := func(node dag.Node) bool {
-		if !dag.Implements[*drone.Compiler]()(node) {
+		if !dag.Implements[drone.Compiler]()(node) {
 			return false
 		}
 

--- a/internal/project/golang/build.go
+++ b/internal/project/golang/build.go
@@ -120,7 +120,7 @@ func (build *Build) CompileDockerfile(output *dockerfile.Output) error {
 
 // CompileDrone implements drone.Compiler.
 func (build *Build) CompileDrone(output *drone.Output) error {
-	output.Step(drone.MakeStep(build.Name()).DependsOn(dag.GatherMatchingInputNames(build, dag.Implements[*drone.Compiler]())...))
+	output.Step(drone.MakeStep(build.Name()).DependsOn(dag.GatherMatchingInputNames(build, dag.Implements[drone.Compiler]())...))
 
 	return nil
 }

--- a/internal/project/golang/toolchain.go
+++ b/internal/project/golang/toolchain.go
@@ -121,7 +121,7 @@ func (toolchain *Toolchain) CompileMakefile(output *makefile.Output) error {
 		)
 
 	output.Target("base").
-		Depends(dag.GatherMatchingInputNames(toolchain, dag.Implements[*dockerfile.Generator]())...).
+		Depends(dag.GatherMatchingInputNames(toolchain, dag.Implements[dockerfile.Generator]())...).
 		Description("Prepare base toolchain").
 		Script("@$(MAKE) target-$@").
 		Phony()
@@ -132,7 +132,7 @@ func (toolchain *Toolchain) CompileMakefile(output *makefile.Output) error {
 // CompileDrone implements drone.Compiler.
 func (toolchain *Toolchain) CompileDrone(output *drone.Output) error {
 	output.Step(drone.MakeStep("base").
-		DependsOn(dag.GatherMatchingInputNames(toolchain, dag.Implements[*drone.Compiler]())...),
+		DependsOn(dag.GatherMatchingInputNames(toolchain, dag.Implements[drone.Compiler]())...),
 	)
 
 	return nil
@@ -190,7 +190,7 @@ func (toolchain *Toolchain) CompileDockerfile(output *dockerfile.Output) error {
 	}
 
 	// build chain of gen containers.
-	inputs := dag.GatherMatchingInputs(toolchain, dag.Implements[*dockerfile.Generator]())
+	inputs := dag.GatherMatchingInputs(toolchain, dag.Implements[dockerfile.Generator]())
 	for _, input := range inputs {
 		for _, path := range input.(dockerfile.Generator).GetArtifacts() { //nolint:forcetypeassert
 			base.Step(step.Copy(path, "./"+strings.Trim(path, "/")).From(input.Name()))

--- a/internal/project/golang/unit_tests.go
+++ b/internal/project/golang/unit_tests.go
@@ -98,11 +98,11 @@ func (tests *UnitTests) CompileMakefile(output *makefile.Output) error {
 // CompileDrone implements drone.Compiler.
 func (tests *UnitTests) CompileDrone(output *drone.Output) error {
 	output.Step(drone.MakeStep("unit-tests").
-		DependsOn(dag.GatherMatchingInputNames(tests, dag.Implements[*drone.Compiler]())...),
+		DependsOn(dag.GatherMatchingInputNames(tests, dag.Implements[drone.Compiler]())...),
 	)
 
 	output.Step(drone.MakeStep("unit-tests-race").
-		DependsOn(dag.GatherMatchingInputNames(tests, dag.Implements[*drone.Compiler]())...),
+		DependsOn(dag.GatherMatchingInputNames(tests, dag.Implements[drone.Compiler]())...),
 	)
 
 	return nil

--- a/internal/project/js/build.go
+++ b/internal/project/js/build.go
@@ -83,7 +83,7 @@ func (build *Build) CompileDockerfile(output *dockerfile.Output) error {
 
 // CompileDrone implements drone.Compiler.
 func (build *Build) CompileDrone(output *drone.Output) error {
-	output.Step(drone.MakeStep(build.Name()).DependsOn(dag.GatherMatchingInputNames(build, dag.Implements[*drone.Compiler]())...))
+	output.Step(drone.MakeStep(build.Name()).DependsOn(dag.GatherMatchingInputNames(build, dag.Implements[drone.Compiler]())...))
 
 	return nil
 }

--- a/internal/project/js/toolchain.go
+++ b/internal/project/js/toolchain.go
@@ -98,7 +98,7 @@ func (toolchain *Toolchain) CompileMakefile(output *makefile.Output) error {
 // CompileDrone implements drone.Compiler.
 func (toolchain *Toolchain) CompileDrone(output *drone.Output) error {
 	output.Step(drone.MakeStep("js").
-		DependsOn(dag.GatherMatchingInputNames(toolchain, dag.Implements[*drone.Compiler]())...),
+		DependsOn(dag.GatherMatchingInputNames(toolchain, dag.Implements[drone.Compiler]())...),
 	)
 
 	return nil

--- a/internal/project/js/unit_tests.go
+++ b/internal/project/js/unit_tests.go
@@ -56,7 +56,7 @@ func (tests *UnitTests) CompileMakefile(output *makefile.Output) error {
 // CompileDrone implements drone.Compiler.
 func (tests *UnitTests) CompileDrone(output *drone.Output) error {
 	output.Step(drone.MakeStep(tests.Name()).
-		DependsOn(dag.GatherMatchingInputNames(tests, dag.Implements[*drone.Compiler]())...),
+		DependsOn(dag.GatherMatchingInputNames(tests, dag.Implements[drone.Compiler]())...),
 	)
 
 	return nil

--- a/internal/project/service/codecov.go
+++ b/internal/project/service/codecov.go
@@ -44,7 +44,7 @@ func (coverage *CodeCov) CompileDrone(output *drone.Output) error {
 	}
 
 	output.Step(drone.MakeStep("coverage").
-		DependsOn(dag.GatherMatchingInputNames(coverage, dag.Implements[*drone.Compiler]())...).
+		DependsOn(dag.GatherMatchingInputNames(coverage, dag.Implements[drone.Compiler]())...).
 		EnvironmentFromSecret("CODECOV_TOKEN", "CODECOV_TOKEN"),
 	)
 


### PR DESCRIPTION
We can actually assert to the type directly and do not call reflect package functions.

Signed-off-by: Dmitriy Matrenichev <dmitry.matrenichev@siderolabs.com>