### PR TITLE
feat: introduce an option to copy assets into image from a stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2022-10-24T13:36:25Z by kres ef0ba25-dirty.
+# Generated on 2022-11-10T12:19:49Z by kres 2131c78-dirty.
 
 ARG TOOLCHAIN
 
@@ -104,6 +104,9 @@ FROM scratch AS unit-tests
 COPY --from=unit-tests-run /src/coverage.txt /coverage.txt
 
 FROM kres-linux-${TARGETARCH} AS kres
+
+FROM scratch AS kres-all
+COPY --from=kres-linux-amd64 / /
 
 FROM scratch AS image-kres
 ARG TARGETARCH

--- a/internal/project/golang/build.go
+++ b/internal/project/golang/build.go
@@ -111,6 +111,14 @@ func (build *Build) CompileDockerfile(output *dockerfile.Output) error {
 		addBuildSteps(artifact.name, artifact.config)
 	}
 
+	// combine all binaries built for each arch into '-all' stage
+	all := output.Stage(fmt.Sprintf("%s-all", build.Name())).
+		From("scratch")
+
+	for _, artifact := range build.getArtifacts() {
+		all.Step(step.Copy("/", "/").From(artifact.name))
+	}
+
 	build.entrypoint = fmt.Sprintf("%s-linux-${TARGETARCH}", build.Name())
 	output.Stage(build.Name()).
 		From(build.entrypoint)


### PR DESCRIPTION
This also adds a Dockerfile step which combines all Go binaries built for different arches into `<cmd>-all` step.

Example usage:

```yaml
kind: common.Image
name: image-foo
spec:
  copyFrom:
    - stage: fooctl-all
      destination: /assets/fooctl/
```

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>