### PR TITLE
chore: minor fixes and updates

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,8 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2021-08-11T16:23:52Z by kres c77e3bf-dirty.
+# Generated on 2022-11-13T18:59:41Z by kres b4a6481.
 
-**
+*
 !cmd
 !internal
 !go.mod

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/siderolabs/kres
 go 1.19
 
 require (
-	github.com/SOF3/go-stable-toposort v0.0.0-20180826141444-ba650b7de8a0
 	github.com/drone/drone-yaml v1.2.3
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/google/go-github/v44 v44.1.0

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,6 @@ github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C67SkzkDfmQuVln04ygHj3vjZfd9FL+GmQQ=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
-github.com/SOF3/go-stable-toposort v0.0.0-20180826141444-ba650b7de8a0 h1:yvjg2ZCtDeq/CFKsLSG8+d0y5/jyEWugf23o8EkbySE=
-github.com/SOF3/go-stable-toposort v0.0.0-20180826141444-ba650b7de8a0/go.mod h1:/qO7k8y0mor8qdFf5E3GLiH9e7vpn0sP3wj/Jigpl/8=
 github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=
 github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/internal/output/dockerfile/stage.go
+++ b/internal/output/dockerfile/stage.go
@@ -10,8 +10,6 @@ import (
 	"regexp"
 	"strings"
 
-	stableToposort "github.com/SOF3/go-stable-toposort"
-
 	"github.com/siderolabs/kres/internal/output/dockerfile/step"
 )
 
@@ -61,9 +59,7 @@ func (stage *Stage) Dependencies() []string {
 }
 
 // Before implements stableToposort.Node interface.
-func (stage *Stage) Before(node stableToposort.Node) bool {
-	otherStage := node.(*Stage) //nolint:errcheck,forcetypeassert
-
+func (stage *Stage) Before(otherStage *Stage) bool {
 	for _, dep := range otherStage.Dependencies() {
 		sanitized := stripVars.ReplaceAllString(dep, "")
 		if sanitized != dep && sanitized != "" {

--- a/internal/toposort/toposort.go
+++ b/internal/toposort/toposort.go
@@ -1,0 +1,132 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package toposort provides stable toposort implementation.
+package toposort
+
+// Most of this implementation is based on github.com/SOF3/go-stable-toposort
+
+import (
+	"sort"
+)
+
+// Node is a node.
+type Node[T any] interface {
+	Before(other T) bool
+}
+
+type (
+	nodeNumber = int
+	edgeNumber = int
+	edge       [2]nodeNumber
+)
+
+type edgeIndex struct {
+	index [2]map[nodeNumber]map[nodeNumber]edgeNumber
+	slice []edge
+}
+
+func newEdgeIndex() *edgeIndex {
+	index := &edgeIndex{}
+
+	for i := range index.index {
+		index.index[i] = map[nodeNumber]map[nodeNumber]edgeNumber{}
+	}
+
+	return index
+}
+
+func (index *edgeIndex) add(edge edge) edgeNumber {
+	number := len(index.slice)
+	index.slice = append(index.slice, edge)
+
+	for pos := range index.index {
+		if _, exists := index.index[pos][edge[pos]]; !exists {
+			index.index[pos][edge[pos]] = make(map[nodeNumber]edgeNumber)
+		}
+
+		index.index[pos][edge[pos]][edge[1-pos]] = number
+	}
+
+	return number
+}
+
+func (index *edgeIndex) removeIndex(edge edge) {
+	for pos := range [...]int{0, 1} {
+		delete(index.index[pos][edge[pos]], edge[1-pos])
+
+		if len(index.index[pos][edge[pos]]) == 0 {
+			delete(index.index[pos], edge[pos])
+		}
+	}
+}
+
+// Stable sorts nodes by Kahn's algorithm.
+func Stable[N Node[N]](nodes []N) (output []N, cycle []N) {
+	edges := newEdgeIndex()
+
+	for i := 0; i < len(nodes); i++ {
+		for j := i + 1; j < len(nodes); j++ {
+			ij := nodes[i].Before(nodes[j])
+			ji := nodes[j].Before(nodes[i])
+
+			if ij && ji {
+				return nil, []N{nodes[i], nodes[j]}
+			}
+
+			if ij {
+				edges.add(edge{i, j})
+			} else if ji {
+				edges.add(edge{j, i})
+			}
+		}
+	}
+
+	output = make([]N, 0, len(nodes))
+	roots := make([]nodeNumber, 0, len(nodes))
+
+	for mInt := range nodes {
+		m := mInt
+		if _, hasBefore := edges.index[1][m]; !hasBefore {
+			roots = append(roots, m)
+		}
+	}
+
+	for len(roots) > 0 {
+		n := roots[0]
+		roots = roots[1:]
+
+		output = append(output, nodes[n])
+
+		slc := make([]nodeNumber, 0, len(edges.index[0][n]))
+		for m := range edges.index[0][n] {
+			slc = append(slc, m)
+		}
+
+		sort.SliceStable(slc, func(i, j int) bool { return slc[i] < slc[j] }) // stabilize the output because we are using a map
+
+		for _, m := range slc {
+			e := edges.index[0][n][m]
+
+			edges.removeIndex(edges.slice[e])
+
+			if _, hasBefore := edges.index[1][m]; !hasBefore {
+				roots = append(roots, m)
+			}
+		}
+	}
+
+	for pos := range edges.index {
+		if len(edges.index[pos]) > 0 {
+			cycle = make([]N, 0, len(edges.index[0]))
+			for n := range edges.index[pos] {
+				cycle = append(cycle, nodes[n])
+			}
+
+			return nil, cycle
+		}
+	}
+
+	return output, nil
+}

--- a/internal/toposort/toposort_test.go
+++ b/internal/toposort/toposort_test.go
@@ -1,0 +1,73 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package toposort_test
+
+import (
+	"testing"
+
+	"github.com/siderolabs/kres/internal/toposort"
+)
+
+type testNode int
+
+func (n testNode) Before(m testNode) bool {
+	type pair = [2]testNode
+
+	switch (pair{n, m}) {
+	case pair{5, 11}:
+		return true
+	case pair{7, 11}:
+		return true
+	case pair{7, 8}:
+		return true
+	case pair{3, 8}:
+		return true
+	case pair{3, 10}:
+		return true
+	case pair{11, 2}:
+		return true
+	case pair{11, 10}:
+		return true
+	case pair{11, 9}:
+		return true
+	case pair{8, 9}:
+		return true
+	default:
+		return false
+	}
+}
+
+func TestSort(t *testing.T) {
+	for i := 0; i < 10000; i++ {
+		testnodes := []testNode{
+			testNode(10),
+			testNode(2),
+			testNode(5),
+			testNode(3),
+			testNode(11),
+			testNode(8),
+			testNode(9),
+			testNode(7),
+		}
+
+		sorted, bad := toposort.Stable(testnodes)
+
+		if bad != nil {
+			t.Errorf("returned bad: %v", bad)
+			t.Fail()
+		}
+
+		expected := []testNode{5, 3, 7, 11, 8, 10, 2, 9}
+
+		for j := 0; j < len(sorted) || j < len(expected); j++ {
+			if sorted[j] != expected[j] {
+				t.Logf("%v", sorted)
+
+				t.Errorf("%v != %v", sorted[j], expected[j])
+				t.FailNow()
+			}
+		}
+	}
+}


### PR DESCRIPTION
- Add one asterisk instead of two at the beginning of the `.dockerignore` file. This is important because `docker compose` do not understand our current pattern. As for top level `**` and `*` without slashes and characters should make no difference.
- Move toposort into the project, use generics for implementation. Drop type assertions.

Signed-off-by: Dmitriy Matrenichev <dmitry.matrenichev@siderolabs.com>