### PR TITLE
feat: add support for custom .gitignore paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2020-08-11T14:39:25Z by kres ced23da-dirty.
+# Generated on 2022-11-28T15:57:44Z by kres 3ac53a8-dirty.
 
 _out
+_out/example/

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -22,3 +22,8 @@ spec:
 kind: service.CodeCov
 spec:
     targetThreshold: 10
+---
+kind: common.Build
+spec:
+    ignoredPaths:
+        - "_out/example/"

--- a/internal/project/common/build.go
+++ b/internal/project/common/build.go
@@ -19,7 +19,8 @@ type Build struct {
 
 	meta *meta.Options
 
-	ArtifactsPath string `yaml:"artifactsPath"`
+	ArtifactsPath string   `yaml:"artifactsPath"`
+	IgnoredPaths  []string `yaml:"ignoredPaths"`
 }
 
 // NewBuild initializes Build.
@@ -66,8 +67,11 @@ func (build *Build) CompileMakefile(output *makefile.Output) error {
 
 // CompileGitignore implements gitignore.Compiler.
 func (build *Build) CompileGitignore(output *gitignore.Output) error {
-	output.
-		IgnorePath(build.ArtifactsPath)
+	output.IgnorePath(build.ArtifactsPath)
+
+	for _, ignoredPath := range build.IgnoredPaths {
+		output.IgnorePath(ignoredPath)
+	}
 
 	return nil
 }


### PR DESCRIPTION
Now you can add `ignoredPaths` list to `common.Build` spec.

Signed-off-by: Dmitriy Matrenichev <dmitry.matrenichev@siderolabs.com>