### PR TITLE
feat: add support for generating arbitrary files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,15 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2023-01-12T10:59:58Z by kres e209704.
+# Generated on 2023-01-24T18:26:41Z by kres dc2a7bb.
 
 ARG TOOLCHAIN
 
 # cleaned up specs and compiled versions
 FROM scratch AS generate
+
+# generates static files
+FROM scratch AS generate-files
 
 FROM ghcr.io/siderolabs/ca-certificates:v1.3.0 AS image-ca-certificates
 

--- a/internal/project/auto/builder.go
+++ b/internal/project/auto/builder.go
@@ -112,11 +112,12 @@ func (builder *builder) build() error {
 	rekres := common.NewReKres(builder.meta)
 	makeHelp := common.NewMakeHelp(builder.meta)
 	conformance := common.NewConformance(builder.meta)
+	generate := common.NewGenerate(builder.meta)
 
 	release.AddInput(builder.targets...)
 
 	builder.proj.AddTarget(builder.targets...)
-	builder.proj.AddTarget(rekres, all, makeHelp, release, conformance)
+	builder.proj.AddTarget(rekres, all, makeHelp, release, conformance, generate)
 
 	return nil
 }

--- a/internal/project/common/generate.go
+++ b/internal/project/common/generate.go
@@ -1,0 +1,53 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package common
+
+import (
+	"path/filepath"
+
+	"github.com/siderolabs/kres/internal/dag"
+	"github.com/siderolabs/kres/internal/output/dockerfile"
+	"github.com/siderolabs/kres/internal/output/dockerfile/step"
+	"github.com/siderolabs/kres/internal/project/meta"
+)
+
+// Generate provides .proto compilation with grpc-go plugin
+// and go generate runner.
+type Generate struct {
+	dag.BaseNode
+
+	meta *meta.Options
+
+	Files []File `yaml:"files"`
+}
+
+// File represents file to be generated (copied or downloaded).
+type File struct {
+	Source      string `yaml:"source"`
+	Destination string `yaml:"destination"`
+}
+
+// NewGenerate builds Generate node.
+func NewGenerate(meta *meta.Options) *Generate {
+	return &Generate{
+		BaseNode: dag.NewBaseNode("generate-files"),
+		meta:     meta,
+	}
+}
+
+// CompileDockerfile implements dockerfile.Compiler.
+func (generate *Generate) CompileDockerfile(output *dockerfile.Output) error {
+	generateStage := output.Stage("generate-files").
+		Description("generates static files").
+		From("scratch")
+
+	for _, file := range generate.Files {
+		generateStage.Step(
+			step.Add(file.Source, filepath.Join("/", file.Destination)),
+		)
+	}
+
+	return nil
+}

--- a/internal/project/common/generate_test.go
+++ b/internal/project/common/generate_test.go
@@ -1,0 +1,18 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package common_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/siderolabs/kres/internal/output/dockerfile"
+	"github.com/siderolabs/kres/internal/project/common"
+)
+
+func TestGenerateInterfaces(t *testing.T) {
+	assert.Implements(t, (*dockerfile.Compiler)(nil), new(common.Generate))
+}

--- a/internal/project/golang/generate.go
+++ b/internal/project/golang/generate.go
@@ -280,6 +280,7 @@ func (generate *Generate) CompileDockerfile(output *dockerfile.Output) error {
 			From("base").
 			Step(step.WorkDir("/src")).
 			Step(step.Copy(license.Header, filepath.Join("./hack/", license.Header))).
+			Step(step.Copy("/", "./").From("generate-files")).
 			Step(step.Script(fmt.Sprintf("go generate %s/...", spec.Source)).
 				MountCache(filepath.Join(generate.meta.CachePath, "go-build")).
 				MountCache(filepath.Join(generate.meta.GoPath, "pkg")),

--- a/internal/project/js/build.go
+++ b/internal/project/js/build.go
@@ -71,6 +71,8 @@ func (build *Build) CompileDockerfile(output *dockerfile.Output) error {
 		Description(fmt.Sprintf("builds %s", build.Name())).
 		From("js").
 		Step(step.Arg(nodeBuildArgsVarName)).
+		Step(step.Copy("/", "/generated").From("generate-files")).
+		Step(step.Script(fmt.Sprintf("cp -rf /generated/%s/. ./ || true && rm -rf /generated", build.Name()))).
 		Step(step.Script("npm run build ${" + nodeBuildArgsVarName + "}").
 			MountCache(build.meta.NpmCachePath)).
 		Step(step.Script("mkdir -p " + outputDir)).


### PR DESCRIPTION
Add `common.Generate` node type which can bring files from the local filesystem or from an HTTP URL to the desired destination.

We do it before building the frontend, so that the resources that are brought in can be embedded/used by the build.

Signed-off-by: Utku Ozdemir <utku.ozdemir@siderolabs.com>