### PR TITLE
feat: add git to build container

### DIFF
--- a/internal/project/golang/toolchain.go
+++ b/internal/project/golang/toolchain.go
@@ -147,7 +147,7 @@ func (toolchain *Toolchain) CompileDockerfile(output *dockerfile.Output) error {
 		From("${TOOLCHAIN}")
 
 	if toolchain.Kind == ToolchainOfficial {
-		packages := []string{"add", "bash", "curl", "build-base", "protoc", "protobuf-dev"}
+		packages := []string{"add", "bash", "curl", "build-base", "protoc", "protobuf-dev", "git"}
 		packages = append(packages, toolchain.ExtraPackages...)
 
 		toolchainStage.


### PR DESCRIPTION
This PR adds git to the list of packages in the build container. This is needed to build go projects with private modules.

Signed-off-by: Spencer Smith <spencer.smith@talos-systems.com>