### PR TITLE
feat: add ability to build with private git repos

### DIFF
--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -41,6 +41,16 @@ func (project *Contents) LoadConfig(config *config.Provider) error {
 	visited := make(map[dag.Node]struct{})
 
 	return dag.Walk(project, func(node dag.Node) error {
-		return config.Load(node)
+		if err := config.Load(node); err != nil {
+			return err
+		}
+
+		// allow for nodes to implement an AfterLoad function to edit the loaded config
+		// before compilation starts.
+		if loadHook, ok := node.(interface{ AfterLoad() error }); ok {
+			return loadHook.AfterLoad()
+		}
+
+		return nil
 	}, visited, -1)
 }


### PR DESCRIPTION
This PR adds the ability for kresified repos to use private go libraries by adding a blurb to kres.yaml. Config should look like:

```
kind: golang.Toolchain
spec:
  privateRepos:
    - github.com/siderolabs/omni-controller
```

Of note, this also adds in the `AfterLoad` ability to be able to edit the ingested config before compilation starts. This allows things like being able to do things like conditionally inject docker build args.

Signed-off-by: Spencer Smith <spencer.smith@talos-systems.com>