### PR TITLE
fix: add github token to base drone step

### DIFF
--- a/internal/project/golang/toolchain.go
+++ b/internal/project/golang/toolchain.go
@@ -147,9 +147,13 @@ func (toolchain *Toolchain) CompileMakefile(output *makefile.Output) error {
 
 // CompileDrone implements drone.Compiler.
 func (toolchain *Toolchain) CompileDrone(output *drone.Output) error {
-	output.Step(drone.MakeStep("base").
-		DependsOn(dag.GatherMatchingInputNames(toolchain, dag.Implements[drone.Compiler]())...),
-	)
+	baseStep := drone.MakeStep("base").DependsOn(dag.GatherMatchingInputNames(toolchain, dag.Implements[drone.Compiler]())...)
+
+	if toolchain.PrivateRepos != nil {
+		baseStep = baseStep.EnvironmentFromSecret("GITHUB_TOKEN", "github_token")
+	}
+
+	output.Step(baseStep)
 
 	return nil
 }


### PR DESCRIPTION
This PR finalizes the kres support of private libraries. I missed a step of adding the github token to drone's base step so that the git config setup could work as expected.

Signed-off-by: Spencer Smith <spencer.smith@talos-systems.com>