### PR TITLE
fix: compare status checks correctly

### DIFF
--- a/internal/project/common/repository.go
+++ b/internal/project/common/repository.go
@@ -206,7 +206,11 @@ func (r *Repository) enableBranchProtection(client *github.Client) error {
 			branchProtection.GetRequiredPullRequestReviews().RequiredApprovingReviewCount == req.RequiredPullRequestReviews.RequiredApprovingReviewCount &&
 			branchProtection.GetRequiredStatusChecks() != nil &&
 			branchProtection.GetRequiredStatusChecks().Strict == req.RequiredStatusChecks.Strict &&
-			equalStringSlices(branchProtection.GetRequiredStatusChecks().Contexts, req.RequiredStatusChecks.Contexts) &&
+			equalStringSlices(
+				slices.Map(branchProtection.GetRequiredStatusChecks().Checks,
+					func(s *github.RequiredStatusCheck) string {
+						return s.Context
+					}), enforceContexts) &&
 			sigProtected.GetEnabled() {
 			return nil
 		}


### PR DESCRIPTION
This fixes a fix from 6027a8f55ad4e7e30af4cd9c83197c353395e104 to correctly see that everything is up to date.