### PR TITLE
feat: provide a way to "split" custom steps into pipelines

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,7 +1,7 @@
 ---
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2023-02-13T09:56:10Z by kres c0f18ba-dirty.
+# Generated on 2023-03-01T19:46:03Z by kres 636983d-dirty.
 
 kind: pipeline
 type: kubernetes
@@ -308,6 +308,10 @@ trigger:
     exclude:
     - renovate/*
     - dependabot/*
+  event:
+    exclude:
+    - promote
+    - cron
 
 ---
 kind: pipeline

--- a/internal/dag/base.go
+++ b/internal/dag/base.go
@@ -29,17 +29,6 @@ func (node *BaseNode) Inputs() []Node {
 	return node.inputs
 }
 
-// InputNames implements Node interface.
-func (node *BaseNode) InputNames() []string {
-	names := make([]string, len(node.inputs))
-
-	for i := range names {
-		names[i] = node.inputs[i].Name()
-	}
-
-	return names
-}
-
 // AddInput implements Node interface.
 func (node *BaseNode) AddInput(input ...Node) {
 	node.inputs = append(node.inputs, input...)

--- a/internal/dag/node.go
+++ b/internal/dag/node.go
@@ -4,11 +4,12 @@
 
 package dag
 
+import "github.com/siderolabs/gen/slices"
+
 // Node in directed acyclic graph, recording parent nodes as inputs.
 type Node interface {
 	Name() string
 	Inputs() []Node
-	InputNames() []string
 	AddInput(...Node)
 }
 
@@ -32,29 +33,28 @@ func Not(condition NodeCondition) NodeCondition {
 }
 
 // GatherMatchingInputNames scans all the inputs and returns those which match the condition.
-//
-// If direct input doesn't match a condition, search continues up until matching node is found.
 func GatherMatchingInputNames(node Node, condition NodeCondition) []string {
-	result := []string{}
-
-	for _, input := range node.Inputs() {
-		if condition(input) {
-			result = append(result, input.Name())
-		}
-	}
-
-	return result
+	return slices.Map(GatherMatchingInputs(node, condition), func(input Node) string {
+		return input.Name()
+	})
 }
 
 // GatherMatchingInputs scans all the inputs and returns those which match the condition.
-//
-// If direct input doesn't match a condition, search continues up until matching node is found.
 func GatherMatchingInputs(node Node, condition NodeCondition) []Node {
-	result := []Node{}
+	return slices.Filter(node.Inputs(), func(input Node) bool { return condition(input) })
+}
+
+// GatherMatchingInputsRecursive scans all the inputs recursively and returns those which match the condition.
+func GatherMatchingInputsRecursive(node Node, condition NodeCondition) []Node {
+	result := GatherMatchingInputs(node, condition)
 
 	for _, input := range node.Inputs() {
-		if condition(input) {
-			result = append(result, input)
+		downstream := GatherMatchingInputsRecursive(input, condition)
+
+		for _, downstreamInput := range downstream {
+			if !slices.Contains(result, func(n Node) bool { return n == downstreamInput }) {
+				result = append(result, downstreamInput)
+			}
 		}
 	}
 

--- a/internal/output/drone/pipeline.go
+++ b/internal/output/drone/pipeline.go
@@ -1,0 +1,27 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package drone
+
+import "github.com/drone/drone-yaml/yaml"
+
+// Pipeline wraps custom pipelines to handle step appending.
+type Pipeline struct {
+	drone     *Output
+	pipelines []*yaml.Pipeline
+}
+
+// Step appends a step to the pipeline.
+func (p *Pipeline) Step(step *Step) {
+	for _, pipeline := range p.pipelines {
+		p.drone.appendStep(step, pipeline)
+	}
+}
+
+// Service appends a new service.
+func (p *Pipeline) Service(service *yaml.Container) {
+	for _, pipeline := range p.pipelines {
+		p.drone.appendService(service, pipeline)
+	}
+}

--- a/internal/output/drone/service.go
+++ b/internal/output/drone/service.go
@@ -7,10 +7,16 @@ package drone
 import "github.com/drone/drone-yaml/yaml"
 
 // Service appends a new service.
-func (o *Output) Service(spec *yaml.Container) *Output {
+func (o *Output) Service(spec *yaml.Container) {
+	o.appendService(spec, o.defaultPipeline)
+}
+
+func (o *Output) appendService(originalService *yaml.Container, pipeline *yaml.Pipeline) {
+	// perform a shallow copy of the step to avoid modifying the original
+	spec := *originalService
+
+	spec.Volumes = append([]*yaml.VolumeMount{}, spec.Volumes...)
 	spec.Volumes = append(spec.Volumes, o.standardMounts...)
 
-	o.defaultPipeline.Services = append(o.defaultPipeline.Services, spec)
-
-	return o
+	pipeline.Services = append(pipeline.Services, &spec)
 }

--- a/internal/project/common/docker.go
+++ b/internal/project/common/docker.go
@@ -50,6 +50,13 @@ func (docker *Docker) CompileDrone(output *drone.Output) error {
 		VolumeTemporary("buildx", "/root/.docker/buildx").
 		VolumeTemporary("ssh", "/root/.ssh")
 
+	docker.BuildBaseDroneSteps(output)
+
+	return nil
+}
+
+// BuildBaseDroneSteps builds the base steps which start the pipeline.
+func (docker *Docker) BuildBaseDroneSteps(output drone.StepService) {
 	resources := (*yaml.Resources)(nil)
 	if docker.DockerResourceRequests != nil {
 		resources = &yaml.Resources{
@@ -89,8 +96,6 @@ func (docker *Docker) CompileDrone(output *drone.Output) error {
 			"docker buildx inspect --bootstrap",
 		).EnvironmentFromSecret("SSH_KEY", "ssh_key"),
 	)
-
-	return nil
 }
 
 // CompileMakefile implements makefile.Compiler.


### PR DESCRIPTION
This allows to run multiple versions of the step in different pipelines with cron schedule and promote rules, saving/loading artifacts on the way.

The design comes from the Talos pipelines.