### PR TITLE
chore: disable `loopclosure` in `govet`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -74,6 +74,8 @@ linters-settings:
   govet:
     check-shadowing: true
     enable-all: true
+    disable:
+      - loopclosure
   lll:
     line-length: 200
     tab-width: 4

--- a/internal/output/golangci/golangci.yml
+++ b/internal/output/golangci/golangci.yml
@@ -70,6 +70,8 @@ linters-settings:
   govet:
     check-shadowing: true
     enable-all: true
+    disable:
+      - loopclosure
   lll:
     line-length: 200
     tab-width: 4


### PR DESCRIPTION
Since we enabled `GOEXPERIMENT=loopvar` we do not want this check to report errors.