### PR TITLE
feat: disable provenance on buildkit builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2023-08-10T14:53:01Z by kres eee9fa2.
+# Generated on 2023-08-14T13:43:01Z by kres latest.
 
 # common variables
 
@@ -40,6 +40,7 @@ PROGRESS ?= auto
 PUSH ?= false
 CI_ARGS ?=
 COMMON_ARGS = --file=Dockerfile
+COMMON_ARGS += --provenance=false
 COMMON_ARGS += --progress=$(PROGRESS)
 COMMON_ARGS += --platform=$(PLATFORM)
 COMMON_ARGS += --push=$(PUSH)

--- a/internal/project/common/docker.go
+++ b/internal/project/common/docker.go
@@ -101,6 +101,7 @@ func (docker *Docker) BuildBaseDroneSteps(output drone.StepService) {
 // CompileMakefile implements makefile.Compiler.
 func (docker *Docker) CompileMakefile(output *makefile.Output) error {
 	buildArgs := makefile.RecursiveVariable("COMMON_ARGS", "--file=Dockerfile").
+		Push("--provenance=false").
 		Push("--progress=$(PROGRESS)").
 		Push("--platform=$(PLATFORM)").
 		Push("--push=$(PUSH)")


### PR DESCRIPTION
It dos not bring any value at the moment, and causing the image to not be linked to a repo on GitHub because the way `LABEL org.opencontainers.image.source` is set when it is enabled.