### PR TITLE
fix: mount /dev from the host into docker service

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,7 +1,7 @@
 ---
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2023-06-04T07:49:16Z by kres 44333ed.
+# Generated on 2023-08-31T15:39:43Z by kres d3c3205-dirty.
 
 kind: pipeline
 type: kubernetes
@@ -280,6 +280,8 @@ services:
   - --log-level=error
   privileged: true
   volumes:
+  - name: dev
+    path: /dev
   - name: outer-docker-socket
     path: /var/outer-run
   - name: docker-socket
@@ -302,6 +304,9 @@ volumes:
 - name: ssh
   temp:
     medium: memory
+- name: dev
+  host:
+    path: /dev
 
 trigger:
   branch:

--- a/internal/output/drone/volume.go
+++ b/internal/output/drone/volume.go
@@ -8,16 +8,23 @@ import "github.com/drone/drone-yaml/yaml"
 
 // VolumeHostPath adds a host path mount.
 func (o *Output) VolumeHostPath(name, hostPath, mountPath string) *Output {
+	o.VolumeHostPathStandalone(name, hostPath)
+
+	o.standardMounts = append(o.standardMounts, &yaml.VolumeMount{
+		Name:      name,
+		MountPath: mountPath,
+	})
+
+	return o
+}
+
+// VolumeHostPathStandalone adds a host path mount, but doesn't make it default mount.
+func (o *Output) VolumeHostPathStandalone(name, hostPath string) *Output {
 	o.volumes = append(o.volumes, &yaml.Volume{
 		Name: name,
 		HostPath: &yaml.VolumeHostPath{
 			Path: hostPath,
 		},
-	})
-
-	o.standardMounts = append(o.standardMounts, &yaml.VolumeMount{
-		Name:      name,
-		MountPath: mountPath,
 	})
 
 	return o

--- a/internal/project/common/docker.go
+++ b/internal/project/common/docker.go
@@ -48,7 +48,8 @@ func (docker *Docker) CompileDrone(output *drone.Output) error {
 		VolumeHostPath("outer-docker-socket", "/var/ci-docker", "/var/outer-run").
 		VolumeTemporary("docker-socket", "/var/run").
 		VolumeTemporary("buildx", "/root/.docker/buildx").
-		VolumeTemporary("ssh", "/root/.ssh")
+		VolumeTemporary("ssh", "/root/.ssh").
+		VolumeHostPathStandalone("dev", "/dev")
 
 	docker.BuildBaseDroneSteps(output)
 
@@ -76,6 +77,12 @@ func (docker *Docker) BuildBaseDroneSteps(output drone.StepService) {
 			"--log-level=error",
 		},
 		Resources: resources,
+		Volumes: []*yaml.VolumeMount{
+			{
+				Name:      "dev",
+				MountPath: "/dev",
+			},
+		},
 	})
 
 	builderName := "local"


### PR DESCRIPTION
This allows privileged docker containers running with docker service to access all devices (this is required for loop devices to work properly).