### PR TITLE
fix: handle error returns from GitHub API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2023-09-18T11:05:10Z by kres 90499df-dirty.
+# Generated on 2023-09-19T18:27:09Z by kres ae47820-dirty.
 
 # common variables
 
@@ -214,7 +214,7 @@ image-kres:  ## Builds image for kres.
 .PHONY: rekres
 rekres:
 	@docker pull $(KRES_IMAGE)
-	@docker run --rm -v $(PWD):/src -w /src -e GITHUB_TOKEN $(KRES_IMAGE)
+	@docker run --rm --net=host -v $(PWD):/src -w /src -e GITHUB_TOKEN $(KRES_IMAGE)
 
 .PHONY: help
 help:  ## This help menu.

--- a/internal/project/common/rekres.go
+++ b/internal/project/common/rekres.go
@@ -37,7 +37,7 @@ func (rekres *ReKres) CompileMakefile(output *makefile.Output) error {
 
 	output.Target(rekres.Name()).
 		Script("@docker pull $(KRES_IMAGE)").
-		Script("@docker run --rm -v $(PWD):/src -w /src -e GITHUB_TOKEN $(KRES_IMAGE)").
+		Script("@docker run --rm --net=host -v $(PWD):/src -w /src -e GITHUB_TOKEN $(KRES_IMAGE)").
 		Phony()
 
 	return nil

--- a/internal/project/common/repository.go
+++ b/internal/project/common/repository.go
@@ -140,7 +140,7 @@ func (r *Repository) CompileGitHub(client *github.Client) error {
 func (r *Repository) enableBranchProtection(client *github.Client) error {
 	branchProtection, resp, err := client.Repositories.GetBranchProtection(context.Background(), r.meta.GitHubOrganization, r.meta.GitHubRepository, r.MainBranch)
 	if err != nil {
-		if resp.StatusCode != http.StatusNotFound {
+		if resp == nil || resp.StatusCode != http.StatusNotFound {
 			return err
 		}
 	}


### PR DESCRIPTION
When error is returned, `resp` might be nil (avoids panic).

Run `rekres` in host networking mode to avoid IPv6 fun issues in Docker.