### PR TITLE
fix: custom gh jobs labels sort order

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,11 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2023-10-03T18:24:38Z by kres fde2936.
+# Generated on 2023-10-04T07:25:28Z by kres bf04273-dirty.
 
 name: default
+concurrency:
+  group: ${{ github.event.label == null && github.head_ref || github.run_id }}
+  cancel-in-progress: true
 "on":
   push:
     branches:

--- a/internal/output/ghworkflow/gh_workflow.go
+++ b/internal/output/ghworkflow/gh_workflow.go
@@ -48,10 +48,10 @@ func NewOutput() *Output {
 			ciWorkflow: {
 				Name: "default",
 				// https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-a-fallback-value
-				// Concurrency: Concurrency{
-				// 	Group:            "${{ github.head_ref || github.run_id }}",
-				// 	CancelInProgress: true,
-				// },
+				Concurrency: Concurrency{
+					Group:            "${{ github.event.label == null && github.head_ref || github.run_id }}",
+					CancelInProgress: true,
+				},
 				On: On{
 					Push: Push{
 						Branches: []string{


### PR DESCRIPTION
Sort the `triggerLabels` for GH custom jobs so that `rekres` always have same output.

Also fix the concurrency.