### PR TITLE
fix: properly generate label conditions around `status/ok-to-test` label

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2023-10-04T07:25:28Z by kres bf04273-dirty.
+# Generated on 2023-10-09T12:51:27Z by kres 8529df9-dirty.
 
 name: default
 concurrency:
@@ -25,7 +25,7 @@ jobs:
     runs-on:
       - self-hosted
       - generic
-    if: (!startsWith(github.head_ref, 'renovate/') && !startsWith(github.head_ref, 'dependabot/'))
+    if: (!startsWith(github.head_ref, 'renovate/') && !startsWith(github.head_ref, 'dependabot/')) && contains(github.event.pull_request.labels.*.name, 'status/ok-to-test')
     services:
       buildkitd:
         image: moby/buildkit:v0.12.2

--- a/internal/output/ghworkflow/gh_workflow.go
+++ b/internal/output/ghworkflow/gh_workflow.go
@@ -24,7 +24,7 @@ const (
 	// GenericRunner is the name of the generic runner.
 	GenericRunner = "generic"
 	// DefaultSkipCondition is the default condition to skip the workflow.
-	DefaultSkipCondition = "(!startsWith(github.head_ref, 'renovate/') && !startsWith(github.head_ref, 'dependabot/'))"
+	DefaultSkipCondition = "(!startsWith(github.head_ref, 'renovate/') && !startsWith(github.head_ref, 'dependabot/')) && contains(github.event.pull_request.labels.*.name, 'status/ok-to-test')"
 
 	workflowDir   = ".github/workflows"
 	ciWorkflow    = workflowDir + "/" + "ci.yaml"

--- a/internal/project/custom/custom.go
+++ b/internal/project/custom/custom.go
@@ -419,6 +419,8 @@ func (step *Step) CompileGitHubWorkflow(output *ghworkflow.Output) error {
 		labels := maps.Keys(labelsToMap)
 		slices.Sort(labels)
 
+		labels = append(labels, `"status/ok-to-test"`)
+
 		labelsJSON := fmt.Sprintf("fromJSON('[%s]')", strings.Join(labels, ", "))
 		condition := fmt.Sprintf("%s && (github.event.label == null || (contains(%s, github.event.label.name)))", ghworkflow.DefaultSkipCondition, labelsJSON)
 


### PR DESCRIPTION
Do not start the build unless `status/ok-to-test` is set on the PR. Fix the condition on `labeled` event when `status/ok-to-test` is added.