### PR TITLE
fix: use auto-detected commands as release assets

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2023-10-27T10:34:11Z by kres b20f191-dirty.
+# Generated on 2023-11-01T13:20:25Z by kres 97da358-dirty.
 
 name: default
 concurrency:

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -47,9 +47,3 @@ spec:
 kind: golang.Generate
 spec:
     versionPackagePath: internal/version
----
-kind: common.Release
-name: release
-spec:
-  artifacts:
-    - kres-*

--- a/internal/project/common/release.go
+++ b/internal/project/common/release.go
@@ -26,18 +26,20 @@ type Release struct {
 
 	// List of file patterns relative to the ArtifactsPath to include in the release.
 	//
-	// If not specified, defaults to '["*"]'.
+	// If not specified, defaults to the auto-detected commands.
 	Artifacts []string `yaml:"artifacts"`
 }
 
 // NewRelease initializes Release.
-func NewRelease(meta *meta.Options) *Release {
+func NewRelease(m *meta.Options) *Release {
 	return &Release{
 		BaseNode: dag.NewBaseNode("release"),
 
-		meta: meta,
+		meta: m,
 
-		Artifacts: []string{"*"},
+		Artifacts: xslices.Map(m.Commands, func(cmd meta.Command) string {
+			return cmd.Name + "-*"
+		}),
 	}
 }
 


### PR DESCRIPTION
This drops `_out/*` as the default asset and uses the auto-detected commands as default.

This is a no-op for custom defined outputs.