### PR TITLE
chore: support sudo in CI

### DIFF
--- a/internal/output/ghworkflow/gh_workflow.go
+++ b/internal/output/ghworkflow/gh_workflow.go
@@ -337,6 +337,13 @@ func MakeStep(name string, args ...string) *Step {
 	}
 }
 
+// SetSudo sets step to run with sudo.
+func (step *Step) SetSudo() *Step {
+	step.Run = "sudo -E " + step.Run
+
+	return step
+}
+
 // SetName sets step name.
 func (step *Step) SetName(name string) *Step {
 	step.Name = name

--- a/internal/project/custom/custom.go
+++ b/internal/project/custom/custom.go
@@ -103,6 +103,8 @@ type Step struct {
 		} `yaml:"artifacts"`
 		Enabled bool `yaml:"enabled"`
 	} `yaml:"ghaction"`
+
+	SudoInCI bool `yaml:"sudoInCI"`
 }
 
 // NewStep initializes Step.
@@ -278,6 +280,10 @@ func (step *Step) CompileGitHubWorkflow(output *ghworkflow.Output) error {
 
 	workflowStep := ghworkflow.MakeStep(step.Name())
 
+	if step.SudoInCI {
+		workflowStep.SetSudo()
+	}
+
 	for k, v := range step.GHAction.Environment {
 		workflowStep.SetEnv(k, v)
 	}
@@ -399,6 +405,10 @@ func (step *Step) CompileGitHubWorkflow(output *ghworkflow.Output) error {
 		}
 
 		workflowStep := ghworkflow.MakeStep(step.Name())
+
+		if step.SudoInCI {
+			workflowStep.SetSudo()
+		}
 
 		for k, v := range step.GHAction.Environment {
 			workflowStep.SetEnv(k, v)


### PR DESCRIPTION
Support running commands with `sudo` in CI.
This is useful for GH actions since default commands run as `runner` user.