### PR TITLE
fix: pull request label step condition

### DIFF
--- a/internal/project/pkgfile/build.go
+++ b/internal/project/pkgfile/build.go
@@ -233,6 +233,7 @@ func (pkgfile *Build) CompileGitHubWorkflow(output *ghworkflow.Output) error {
 			&ghworkflow.Step{
 				Name: "Retrieve PR labels",
 				ID:   "retrieve-pr-labels",
+				If:   "github.event_name == 'pull_request' && always()",
 				Uses: fmt.Sprintf("actions/github-script@%s", config.GitHubScriptActionVersion),
 				With: map[string]string{
 					"retries": "3",


### PR DESCRIPTION
Fixes the pull request label retrieve step condition to only run on pull requests.
Also fix the download artifacts steps to be only enabled if artifacts are enabled.