### PR TITLE
fix: gh job outputs

### DIFF
--- a/internal/output/ghworkflow/gh_workflow.go
+++ b/internal/output/ghworkflow/gh_workflow.go
@@ -30,6 +30,8 @@ const (
 
 	// IssueLabelRetrieveScript is the default script to retrieve issue labels.
 	IssueLabelRetrieveScript = `
+if (context.eventName != "pull_request") { return "[]" }
+
 const resp = await github.rest.issues.get({
     issue_number: context.issue.number,
     owner: context.repo.owner,

--- a/internal/project/custom/custom.go
+++ b/internal/project/custom/custom.go
@@ -312,7 +312,6 @@ func (step *Step) CompileGitHubWorkflow(output *ghworkflow.Output) error {
 			&ghworkflow.Step{
 				Name: "Retrieve PR labels",
 				ID:   "retrieve-pr-labels",
-				If:   "github.event_name == 'pull_request' && always()",
 				Uses: fmt.Sprintf("actions/github-script@%s", config.GitHubScriptActionVersion),
 				With: map[string]string{
 					"retries": "3",

--- a/internal/project/pkgfile/build.go
+++ b/internal/project/pkgfile/build.go
@@ -233,7 +233,6 @@ func (pkgfile *Build) CompileGitHubWorkflow(output *ghworkflow.Output) error {
 			&ghworkflow.Step{
 				Name: "Retrieve PR labels",
 				ID:   "retrieve-pr-labels",
-				If:   "github.event_name == 'pull_request' && always()",
 				Uses: fmt.Sprintf("actions/github-script@%s", config.GitHubScriptActionVersion),
 				With: map[string]string{
 					"retries": "3",


### PR DESCRIPTION
This fixes the gh job outputs to return an empty `[]` string if the event is not a pull request. This would fix the GH job failing to evaluate the dependent job condition.