### PR TITLE
chore: bump golangci-lint to v1.56.1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-02-08T17:40:59Z by kres 0bff90e-dirty.
+# Generated on 2024-02-08T23:52:25Z by kres fd08664-dirty.
 
 # options for analysis running
 run:
@@ -74,8 +74,6 @@ linters-settings:
   govet:
     check-shadowing: true
     enable-all: true
-    disable:
-      - loopclosure
   lll:
     line-length: 200
     tab-width: 4

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-02-08T18:12:15Z by kres e29ccc9-dirty.
+# Generated on 2024-02-09T00:25:37Z by kres decf506.
 
 # common variables
 
@@ -19,7 +19,7 @@ GRPC_GO_VERSION ?= 1.3.0
 GRPC_GATEWAY_VERSION ?= 2.19.1
 VTPROTOBUF_VERSION ?= 0.6.0
 DEEPCOPY_VERSION ?= v0.5.5
-GOLANGCILINT_VERSION ?= v1.56.0
+GOLANGCILINT_VERSION ?= v1.56.1
 GOFUMPT_VERSION ?= v0.6.0
 GO_VERSION ?= 1.22.0
 GOIMPORTS_VERSION ?= v0.17.0
@@ -125,7 +125,7 @@ endif
 ifneq (, $(filter $(WITH_DEBUG), t true TRUE y yes 1))
 GO_BUILDFLAGS += -tags sidero.debug
 else
-GO_LDFLAGS += -s -w
+GO_LDFLAGS += -s
 endif
 
 all: unit-tests kres image-kres lint

--- a/cmd/kres/cmd/gen.go
+++ b/cmd/kres/cmd/gen.go
@@ -41,7 +41,7 @@ var genCmd = &cobra.Command{
 	  * Makefile
 	  * Dockerfile`,
 	Args: cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, _ []string) error {
+	RunE: func(*cobra.Command, []string) error {
 		return runGen()
 	},
 }

--- a/cmd/kres/cmd/version.go
+++ b/cmd/kres/cmd/version.go
@@ -17,7 +17,7 @@ var versionCmd = &cobra.Command{
 	Short: "Prints Kres version.",
 	Long:  `Prints Kres version.`,
 	Args:  cobra.NoArgs,
-	Run: func(cmd *cobra.Command, _ []string) {
+	Run: func(*cobra.Command, []string) {
 		line := fmt.Sprintf("%s version %s (%s)", version.Name, version.Tag, version.SHA)
 		fmt.Println(line)
 	},

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -48,7 +48,7 @@ const (
 	GoImportsVersion = "v0.17.0"
 	// GolangCIlintVersion is the version of golangci-lint.
 	// renovate: datasource=go depName=github.com/golangci/golangci-lint
-	GolangCIlintVersion = "v1.56.0"
+	GolangCIlintVersion = "v1.56.1"
 	// GolangContainerImageVersion is the default golang container image.
 	// renovate: datasource=docker versioning=docker depName=golang
 	GolangContainerImageVersion = "1.22-alpine"

--- a/internal/output/golangci/golangci.yml
+++ b/internal/output/golangci/golangci.yml
@@ -70,8 +70,6 @@ linters-settings:
   govet:
     check-shadowing: true
     enable-all: true
-    disable:
-      - loopclosure
   lll:
     line-length: 200
     tab-width: 4

--- a/internal/output/makefile/makefile.go
+++ b/internal/output/makefile/makefile.go
@@ -121,7 +121,7 @@ func (o *Output) makefile(w io.Writer) error {
 		}
 	}
 
-	sort.SliceStable(o.targets, func(i, j int) bool {
+	sort.SliceStable(o.targets, func(i, _ int) bool {
 		return o.targets[i].name == "all"
 	})
 

--- a/internal/project/auto/golang.go
+++ b/internal/project/auto/golang.go
@@ -31,6 +31,10 @@ func (builder *builder) DetectGolang() (bool, error) {
 	var lookupDirs []string
 
 	err := filepath.Walk(builder.rootPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
 		if info.IsDir() {
 			return nil
 		}

--- a/internal/project/golang/toolchain.go
+++ b/internal/project/golang/toolchain.go
@@ -142,7 +142,7 @@ func (toolchain *Toolchain) CompileMakefile(output *makefile.Output) error {
 			makefile.AppendVariable("GO_BUILDFLAGS", "-tags sidero.debug"),
 		).
 		Else(
-			makefile.AppendVariable("GO_LDFLAGS", "-s -w"),
+			makefile.AppendVariable("GO_LDFLAGS", "-s"),
 		)
 
 	output.Target("base").


### PR DESCRIPTION
While I was bumping it to v1.56.0 they released v1.56.1 with more fixes for Go 1.22. So we do a small update.

Also:
- Remove `loopclosure` analysis from disabled list because it's disabled by default for Go >= 1.22.
- Per Go 1.22 release notes "GO_LDFLAGS" "-s -w" and "-s" are equivalent, so move to the latter.