### PR TITLE
feat: add support for `pull_request_target` gh actions event

### DIFF
--- a/internal/output/ghworkflow/types.go
+++ b/internal/output/ghworkflow/types.go
@@ -23,10 +23,11 @@ type Concurrency struct {
 
 // On represents GitHub Actions event triggers.
 type On struct {
-	Push        `yaml:"push,omitempty"`
-	PullRequest `yaml:"pull_request,omitempty"`
-	Schedule    []Schedule `yaml:"schedule,omitempty"`
-	WorkFlowRun `yaml:"workflow_run,omitempty"`
+	Push              `yaml:"push,omitempty"`
+	*PullRequest      `yaml:"pull_request,omitempty"`
+	PullRequestTarget *PullRequest `yaml:"pull_request_target,omitempty"`
+	Schedule          []Schedule   `yaml:"schedule,omitempty"`
+	WorkFlowRun       `yaml:"workflow_run,omitempty"`
 }
 
 // Branches represents GitHub Actions branch filters.
@@ -48,9 +49,6 @@ type WorkFlowRun struct {
 	Workflows []string `yaml:"workflows"`
 	Types     []string `yaml:"types"`
 }
-
-// PullRequestTarget represents GitHub Actions pull request target filters.
-type PullRequestTarget struct{}
 
 // Push represents GitHub Actions push filters.
 type Push struct {

--- a/internal/project/auto/ci.go
+++ b/internal/project/auto/ci.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/siderolabs/kres/internal/config"
+	"github.com/siderolabs/kres/internal/project/ghactions"
 )
 
 // DetectCI checks the ci settings.
@@ -30,6 +31,7 @@ func (builder *builder) BuildCI() error {
 	switch ci.Provider {
 	case config.CIProviderDrone:
 	case config.CIProviderGitHubActions:
+		builder.commonInputs = append(builder.commonInputs, ghactions.NewConfig(builder.meta))
 	default:
 		return fmt.Errorf("unknown ci provider: %s", ci.Provider)
 	}

--- a/internal/project/ghactions/config.go
+++ b/internal/project/ghactions/config.go
@@ -1,0 +1,57 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package ghactions provides GitHub Actions configuration.
+package ghactions
+
+import (
+	"fmt"
+
+	"github.com/siderolabs/kres/internal/dag"
+	"github.com/siderolabs/kres/internal/output/ghworkflow"
+	"github.com/siderolabs/kres/internal/project/meta"
+)
+
+// Config provides GitHub Actions configuration.
+type Config struct {
+	dag.BaseNode
+
+	meta *meta.Options
+
+	// PullRequestEventType is the GitHub action event type to be used for the pull requests.
+	//
+	// Valid values are "pull_request" and "pull_request_target".
+	PullRequestEventType string `yaml:"pullRequestEventType"`
+
+	// CheckoutForkOnPullRequestTarget is a flag to checkout the fork repository and ref when "pull_request_target" event is used.
+	//
+	// This is a safety measure to avoid running the workflow on the forked repository by default.
+	// Used only when pullRequestEventType is "pull_request_target".
+	CheckoutForkOnPullRequestTarget bool `yaml:"checkoutForkOnPullRequestTarget"`
+}
+
+// NewConfig initializes Config.
+func NewConfig(meta *meta.Options) *Config {
+	return &Config{
+		BaseNode: dag.NewBaseNode("ghactions-config"),
+
+		meta: meta,
+
+		PullRequestEventType: "pull_request",
+	}
+}
+
+// CompileGitHubWorkflow implements ghworkflow.Compiler.
+func (config *Config) CompileGitHubWorkflow(output *ghworkflow.Output) error {
+	isPullRequestTarget := config.PullRequestEventType == "pull_request_target"
+
+	if config.PullRequestEventType != "pull_request" && !isPullRequestTarget {
+		return fmt.Errorf("unknown pull request event type: %s", config.PullRequestEventType)
+	}
+
+	output.UsePullRequestTargetEventType = isPullRequestTarget
+	output.CheckoutForkOnPullRequestTarget = config.CheckoutForkOnPullRequestTarget
+
+	return nil
+}


### PR DESCRIPTION
Add support for configuring GitHub actions to use `pull_request_target` event type to trigger workflows instead of the default `pull_request`.

Add support for checking out the fork repository instead of the upstream (target) when this mode is used. By default, the checkout when `pull_request_target` is used will execute in the context of the upstream repository.

These changes allow the workflow runs triggered by the pull requests coming from the forks to be able to access the actions secrets, after the risk is read and understood: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

Enabling both features in `.kres.yaml` looks like:
```
kind: ghactions.Config
spec:
  pullRequestEventType: pull_request_target
  checkoutForkOnPullRequestTarget: true
```