### PR TITLE
fix: make `TAG` getter select only tags starting with `v` prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-03-06T09:45:36Z by kres 1f8340d-dirty.
+# Generated on 2024-03-07T16:58:36Z by kres 0610b40-dirty.
 
 # common variables
 
 SHA := $(shell git describe --match=none --always --abbrev=8 --dirty)
-TAG := $(shell git describe --tag --always --dirty)
+TAG := $(shell git describe --tag --always --dirty --match v[0-9]\*)
 ABBREV_TAG := $(shell git describe --tags >/dev/null 2>/dev/null && git describe --tag --always --match v[0-9]\* --abbrev=0 || echo 'undefined')
 BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 ARTIFACTS := _out

--- a/internal/project/common/build.go
+++ b/internal/project/common/build.go
@@ -62,7 +62,7 @@ func (build *Build) CompileDockerfile(output *dockerfile.Output) error {
 func (build *Build) CompileMakefile(output *makefile.Output) error {
 	variableGroup := output.VariableGroup(makefile.VariableGroupCommon).
 		Variable(makefile.SimpleVariable("SHA", "$(shell git describe --match=none --always --abbrev=8 --dirty)")).
-		Variable(makefile.SimpleVariable("TAG", "$(shell git describe --tag --always --dirty)")).
+		Variable(makefile.SimpleVariable("TAG", "$(shell git describe --tag --always --dirty --match v[0-9]\\*)")).
 		Variable(makefile.SimpleVariable("ABBREV_TAG", "$(shell git describe --tags >/dev/null 2>/dev/null && git describe --tag --always --match v[0-9]\\* --abbrev=0 || echo 'undefined')")).
 		Variable(makefile.SimpleVariable("BRANCH", "$(shell git rev-parse --abbrev-ref HEAD)")).
 		Variable(makefile.SimpleVariable("ARTIFACTS", build.ArtifactsPath))


### PR DESCRIPTION
Treat only semver tags as valid tags.