### PR TITLE
fix: buildx setup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-03-06T10:21:50Z by kres c6cf30a-dirty.
+# Generated on 2024-03-10T20:46:28Z by kres ae93276.
 
 name: default
 concurrency:
@@ -48,7 +48,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           driver: remote
-          endpoint: tcp://localhost:1234
+          endpoint: tcp://127.0.0.1:1234
         timeout-minutes: 1
       - name: base
         run: |

--- a/internal/output/ghworkflow/gh_workflow.go
+++ b/internal/output/ghworkflow/gh_workflow.go
@@ -225,7 +225,7 @@ func DefaultSteps() []*Step {
 			Uses: "docker/setup-buildx-action@" + config.SetupBuildxActionVersion,
 			With: map[string]string{
 				"driver":   "remote",
-				"endpoint": "tcp://localhost:1234",
+				"endpoint": "tcp://127.0.0.1:1234",
 			},
 			TimeoutMinutes: 1,
 		},
@@ -241,7 +241,7 @@ func DefaultPkgsSteps() []*Step {
 			Uses: "docker/setup-buildx-action@" + config.SetupBuildxActionVersion,
 			With: map[string]string{
 				"driver":   "remote",
-				"endpoint": "tcp://localhost:1234",
+				"endpoint": "tcp://127.0.0.1:1234",
 				"append":   strings.TrimPrefix(armbuildkitdEnpointConfig, "\n"),
 			},
 		},


### PR DESCRIPTION
Looking logs I suspect this is just something to do with IPv6. So explicitly use IPv4 address when connecting.