### PR TITLE
fix: Allow repository owner to contains uppercase characters

### DIFF
--- a/internal/project/pkgfile/build.go
+++ b/internal/project/pkgfile/build.go
@@ -103,7 +103,7 @@ func (pkgfile *Build) CompileMakefile(output *makefile.Output) error {
 
 	output.VariableGroup(makefile.VariableGroupCommon).
 		Variable(makefile.OverridableVariable("REGISTRY", "ghcr.io")).
-		Variable(makefile.OverridableVariable("USERNAME", pkgfile.meta.GitHubOrganization)).
+		Variable(makefile.OverridableVariable("USERNAME", strings.ToLower(pkgfile.meta.GitHubOrganization))).
 		Variable(makefile.OverridableVariable("REGISTRY_AND_USERNAME", "$(REGISTRY)/$(USERNAME)"))
 
 	output.VariableGroup(makefile.VariableGroupDocker).


### PR DESCRIPTION
Since repository name must be lowercase it was not possible for users / orgs containing uppercase letter to use Kres