### PR TITLE
fix: split `TAG` and `IMAGE_TAG` veriables

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-03-20T15:59:12Z by kres c2d361c-dirty.
+# Generated on 2024-04-11T10:24:57Z by kres 1d71efa-dirty.
 
 name: default
 concurrency:
@@ -91,7 +91,7 @@ jobs:
           PLATFORM: linux/amd64,linux/arm64
           PUSH: "true"
         run: |
-          make image-kres TAG=latest
+          make image-kres IMAGE_TAG=latest
       - name: Generate Checksums
         if: startsWith(github.ref, 'refs/tags/')
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-04-04T10:18:05Z by kres 5f30198-dirty.
+# Generated on 2024-04-11T10:31:30Z by kres 04ebe4d-dirty.
 
 # common variables
 
@@ -9,6 +9,7 @@ TAG := $(shell git describe --tag --always --dirty --match v[0-9]\*)
 ABBREV_TAG := $(shell git describe --tags >/dev/null 2>/dev/null && git describe --tag --always --match v[0-9]\* --abbrev=0 || echo 'undefined')
 BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 ARTIFACTS := _out
+IMAGE_TAG ?= $(TAG)
 WITH_DEBUG ?= false
 WITH_RACE ?= false
 REGISTRY ?= ghcr.io
@@ -110,7 +111,7 @@ If you already have a compatible builder instance, you may use that instead.
 ## Artifacts
 
 All artifacts will be output to ./$(ARTIFACTS). Images will be tagged with the
-registry "$(REGISTRY)", username "$(USERNAME)", and a dynamic tag (e.g. $(IMAGE):$(TAG)).
+registry "$(REGISTRY)", username "$(USERNAME)", and a dynamic tag (e.g. $(IMAGE):$(IMAGE_TAG)).
 The registry and username can be overridden by exporting REGISTRY, and USERNAME
 respectively.
 
@@ -219,7 +220,7 @@ lint: lint-golangci-lint lint-gofumpt lint-govulncheck lint-goimports lint-markd
 
 .PHONY: image-kres
 image-kres:  ## Builds image for kres.
-	@$(MAKE) target-$@ TARGET_ARGS="--tag=$(REGISTRY)/$(USERNAME)/kres:$(TAG)"
+	@$(MAKE) target-$@ TARGET_ARGS="--tag=$(REGISTRY)/$(USERNAME)/kres:$(IMAGE_TAG)"
 
 .PHONY: rekres
 rekres:

--- a/internal/project/common/build.go
+++ b/internal/project/common/build.go
@@ -65,7 +65,8 @@ func (build *Build) CompileMakefile(output *makefile.Output) error {
 		Variable(makefile.SimpleVariable("TAG", "$(shell git describe --tag --always --dirty --match v[0-9]\\*)")).
 		Variable(makefile.SimpleVariable("ABBREV_TAG", "$(shell git describe --tags >/dev/null 2>/dev/null && git describe --tag --always --match v[0-9]\\* --abbrev=0 || echo 'undefined')")).
 		Variable(makefile.SimpleVariable("BRANCH", "$(shell git rev-parse --abbrev-ref HEAD)")).
-		Variable(makefile.SimpleVariable("ARTIFACTS", build.ArtifactsPath))
+		Variable(makefile.SimpleVariable("ARTIFACTS", build.ArtifactsPath)).
+		Variable(makefile.OverridableVariable("IMAGE_TAG", "$(TAG)"))
 
 	if build.meta.ContainerImageFrontend == config.ContainerImageFrontendDockerfile {
 		variableGroup.Variable(makefile.OverridableVariable("WITH_DEBUG", "false")).

--- a/internal/project/common/image.go
+++ b/internal/project/common/image.go
@@ -80,7 +80,7 @@ func (image *Image) CompileDrone(output *drone.Output) error {
 	output.Step(step)
 
 	if image.PushLatest {
-		step := drone.MakeStep(image.Name(), "TAG=latest").
+		step := drone.MakeStep(image.Name(), "IMAGE_TAG=latest").
 			Name(fmt.Sprintf("push-%s-latest", image.ImageName)).
 			Environment("PUSH", "true").
 			OnlyOnBranch(image.meta.MainBranch).
@@ -128,7 +128,7 @@ func (image *Image) CompileGitHubWorkflow(output *ghworkflow.Output) error {
 	}
 
 	if image.PushLatest {
-		pushStep := ghworkflow.MakeStep(image.Name(), "TAG=latest").
+		pushStep := ghworkflow.MakeStep(image.Name(), "IMAGE_TAG=latest").
 			SetName(fmt.Sprintf("push-%s-latest", image.ImageName)).
 			SetEnv("PUSH", "true").
 			ExceptPullRequest()
@@ -152,7 +152,7 @@ func (image *Image) CompileGitHubWorkflow(output *ghworkflow.Output) error {
 func (image *Image) CompileMakefile(output *makefile.Output) error {
 	target := output.Target(image.Name()).
 		Description(fmt.Sprintf("Builds image for %s.", image.ImageName)).
-		Script(fmt.Sprintf(`@$(MAKE) target-$@ TARGET_ARGS="--tag=$(REGISTRY)/$(USERNAME)/%s:$(TAG)"`, image.ImageName)).
+		Script(fmt.Sprintf(`@$(MAKE) target-$@ TARGET_ARGS="--tag=$(REGISTRY)/$(USERNAME)/%s:$(IMAGE_TAG)"`, image.ImageName)).
 		Phony()
 
 	for _, dependsOn := range image.DependsOn {

--- a/internal/project/common/makehelp.go
+++ b/internal/project/common/makehelp.go
@@ -85,7 +85,7 @@ If you already have a compatible builder instance, you may use that instead.
 ## Artifacts
 
 All artifacts will be output to ./$(ARTIFACTS). Images will be tagged with the
-registry "$(REGISTRY)", username "$(USERNAME)", and a dynamic tag (e.g. $(IMAGE):$(TAG)).
+registry "$(REGISTRY)", username "$(USERNAME)", and a dynamic tag (e.g. $(IMAGE):$(IMAGE_TAG)).
 The registry and username can be overridden by exporting REGISTRY, and USERNAME
 respectively.
 `


### PR DESCRIPTION
This fixes the version of the `:latest` image not to be `latest`, but a proper matching version.

See https://github.com/siderolabs/omni/issues/131