### PR TITLE
fix: allow conform 'max one commit' to be disabled

### DIFF
--- a/internal/output/conform/commitpolicy/commitpolicy.go
+++ b/internal/output/conform/commitpolicy/commitpolicy.go
@@ -60,14 +60,14 @@ type Conventional struct {
 }
 
 // New creates a new commit policy.
-func New(organization string, enableGPGSignatureCheck bool, types, scopes []string) Policy {
+func New(organization string, enableGPGSignatureCheck bool, types, scopes []string, maximumOfOneCommit bool) Policy {
 	return Policy{
 		Type: "commit",
 		Spec: Spec{
 			DCO:                true,
 			GPG:                GPG{Required: enableGPGSignatureCheck, Identity: Identity{GithubOrganization: organization}},
 			Spellcheck:         Spellcheck{Locale: "US"},
-			MaximumOfOneCommit: true,
+			MaximumOfOneCommit: maximumOfOneCommit,
 			Header:             Header{Length: 89, Imperative: true, Case: "lower", InvalidLastCharacters: "."},
 			Body:               Body{Required: true},
 			Conventional:       Conventional{Types: types, Scopes: scopes},

--- a/internal/output/conform/conform.go
+++ b/internal/output/conform/conform.go
@@ -28,6 +28,7 @@ type Output struct {
 	scopes             []string
 	types              []string
 	licensePolicySpecs []licensepolicy.Spec
+	maxOfOneCommit     bool
 
 	licenseCheck      bool
 	gpgSignatureCheck bool
@@ -79,6 +80,11 @@ func (o *Output) SetGPGSignatureCheck(enable bool) {
 	o.gpgSignatureCheck = enable
 }
 
+// SetMaximumOfOneCommit enables single commit check.
+func (o *Output) SetMaximumOfOneCommit(enable bool) {
+	o.maxOfOneCommit = enable
+}
+
 // SetGitHubOrganization scopes GPG identity check to the GitHub organization.
 func (o *Output) SetGitHubOrganization(org string) {
 	o.githubOrg = org
@@ -109,7 +115,7 @@ func (o *Output) config(w io.Writer) error {
 	}
 
 	policyList := []any{
-		commitpolicy.New(o.githubOrg, o.gpgSignatureCheck, o.types, o.scopes),
+		commitpolicy.New(o.githubOrg, o.gpgSignatureCheck, o.types, o.scopes, o.maxOfOneCommit),
 	}
 
 	for _, spec := range o.licensePolicySpecs {

--- a/internal/project/common/repository.go
+++ b/internal/project/common/repository.go
@@ -31,12 +31,13 @@ type Repository struct { //nolint:govet,maligned
 	MainBranch      string   `yaml:"mainBranch"`
 	EnforceContexts []string `yaml:"enforceContexts"`
 
-	EnableConform            bool     `yaml:"enableConform"`
-	ConformWebhookURL        string   `yaml:"conformWebhookURL"`
-	ConformTypes             []string `yaml:"conformTypes"`
-	ConformScopes            []string `yaml:"conformScopes"`
-	ConformLicenseCheck      bool     `yaml:"conformLicenseCheck"`
-	ConformGPGSignatureCheck bool     `yaml:"conformGPGSignatureCheck"`
+	EnableConform             bool     `yaml:"enableConform"`
+	ConformWebhookURL         string   `yaml:"conformWebhookURL"`
+	ConformTypes              []string `yaml:"conformTypes"`
+	ConformScopes             []string `yaml:"conformScopes"`
+	ConformLicenseCheck       bool     `yaml:"conformLicenseCheck"`
+	ConformGPGSignatureCheck  bool     `yaml:"conformGPGSignatureCheck"`
+	ConformMaximumOfOneCommit bool     `yaml:"conformMaximumOfOneCommit"`
 
 	DeprecatedEnableLicense *bool `yaml:"enableLicense"`
 
@@ -80,8 +81,9 @@ func NewRepository(meta *meta.Options) *Repository {
 		ConformScopes: []string{
 			".*",
 		},
-		ConformLicenseCheck:      true,
-		ConformGPGSignatureCheck: true,
+		ConformLicenseCheck:       true,
+		ConformGPGSignatureCheck:  true,
+		ConformMaximumOfOneCommit: true,
 
 		Licenses: []LicenseConfig{
 			{
@@ -125,6 +127,7 @@ func (r *Repository) CompileConform(o *conform.Output) error {
 	o.SetGPGSignatureCheck(r.ConformGPGSignatureCheck)
 	o.SetGitHubOrganization(r.meta.GitHubOrganization)
 	o.SetLicensePolicySpecs(r.LicenseChecks)
+	o.SetMaximumOfOneCommit(r.ConformMaximumOfOneCommit)
 
 	return nil
 }


### PR DESCRIPTION
Required for release/backport branches.