### PR TITLE
fix: codecov upload

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-04-20T16:39:33Z by kres add13d7.
+# Generated on 2024-04-30T10:47:51Z by kres ebc009d-dirty.
 
 name: default
 concurrency:
@@ -61,8 +61,11 @@ jobs:
         run: |
           make unit-tests-race
       - name: coverage
-        run: |
-          make coverage
+        uses: codecov/codecov-action@v4
+        with:
+          files: _out/coverage-unit-tests.txt
+          token: ${{ secrets.CODECOV_TOKEN }}
+        timeout-minutes: 3
       - name: kres
         run: |
           make kres

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-04-15T15:29:32Z by kres cd31f0c.
+# Generated on 2024-04-30T10:44:28Z by kres ebc009d-dirty.
 
 # common variables
 
@@ -175,10 +175,6 @@ unit-tests:  ## Performs unit tests
 .PHONY: unit-tests-race
 unit-tests-race:  ## Performs unit tests with race detection enabled.
 	@$(MAKE) target-$@
-
-.PHONY: coverage
-coverage:  ## Upload coverage data to codecov.io.
-	bash -c "bash <(curl -s https://codecov.io/bash) -f $(ARTIFACTS)/coverage-unit-tests.txt -X fix"
 
 .PHONY: $(ARTIFACTS)/kres-darwin-amd64
 $(ARTIFACTS)/kres-darwin-amd64:

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -25,6 +25,9 @@ const (
 	// CheckOutActionVersion is the version of checkout github action.
 	// renovate: datasource=github-releases extractVersion=^(?<version>v\d+)\.\d+\.\d+$ depName=actions/checkout
 	CheckOutActionVersion = "v4"
+	// CodeCovActionVersion is the version of codecov github action.
+	// renovate: datasource=github-releases extractVersion=^(?<version>v\d+)\.\d+\.\d+$ depName=codecov/codecov-action
+	CodeCovActionVersion = "v4"
 	// DeepCopyVersion is the version of deepcopy.
 	// renovate: datasource=go depName=github.com/siderolabs/deep-copy
 	DeepCopyVersion = "v0.5.6"


### PR DESCRIPTION
Use the official codecov action, since the bash script is deprecated. Also set a timeout on upload so we don't block other steps for too long.