### PR TITLE
feat: add support for gh workflow only kres

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-08T09:34:37Z by kres d15226e-dirty.
+# Generated on 2024-05-14T08:19:55Z by kres f0912c5-dirty.
 
 name: default
 concurrency:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-08T09:34:37Z by kres d15226e-dirty.
+# Generated on 2024-05-01T14:56:14Z by kres fcfe226-dirty.
 
 # common variables
 
@@ -10,6 +10,9 @@ ABBREV_TAG := $(shell git describe --tags >/dev/null 2>/dev/null && git describe
 BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 ARTIFACTS := _out
 IMAGE_TAG ?= $(TAG)
+OPERATING_SYSTEM := $(shell uname -s | tr '[:upper:]' '[:lower:]')
+GOARCH := $(shell uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')
+SOURCE_DATE_EPOCH := $(shell git log -1 --pretty=%ct)
 WITH_DEBUG ?= false
 WITH_RACE ?= false
 REGISTRY ?= ghcr.io
@@ -131,6 +134,9 @@ endif
 
 all: unit-tests kres image-kres lint
 
+$(ARTIFACTS):  ## Creates artifacts directory.
+	@mkdir -p $(ARTIFACTS)
+
 .PHONY: clean
 clean:  ## Cleans up all artifacts.
 	@rm -rf $(ARTIFACTS)
@@ -229,8 +235,7 @@ help:  ## This help menu.
 	@grep -E '^[a-zA-Z%_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 .PHONY: release-notes
-release-notes:
-	mkdir -p $(ARTIFACTS)
+release-notes: $(ARTIFACTS)
 	@ARTIFACTS=$(ARTIFACTS) ./hack/release.sh $@ $(ARTIFACTS)/RELEASE_NOTES.md $(TAG)
 
 .PHONY: conformance

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -91,6 +91,9 @@ const (
 	// SetupBuildxActionVersion is the version of setup-buildx github action.
 	// renovate: datasource=github-releases extractVersion=^(?<version>v\d+)\.\d+\.\d+$ depName=docker/setup-buildx-action
 	SetupBuildxActionVersion = "v3"
+	// SetupTerraformActionVersion is the version of setup terraform github action.
+	// renovate: datasource=github-releases extractVersion=^(?<version>v\d+)\.\d+\.\d+$ depName=hashicorp/setup-terraform
+	SetupTerraformActionVersion = "v3"
 	// SlackNotifyActionVersion is the version of slack notify github action.
 	// renovate: datasource=github-releases extractVersion=^(?<version>v\d+)\.\d+\.\d+$ depName=slackapi/slack-github-action
 	SlackNotifyActionVersion = "v1"

--- a/internal/output/ghworkflow/types.go
+++ b/internal/output/ghworkflow/types.go
@@ -66,7 +66,7 @@ type Job struct {
 	Needs       []string           `yaml:"needs,omitempty"`
 	Outputs     map[string]string  `yaml:"outputs,omitempty"`
 	Services    map[string]Service `yaml:"services,omitempty"`
-	Steps       []*Step            `yaml:"steps"`
+	Steps       []*JobStep         `yaml:"steps"`
 }
 
 // Service represents GitHub Actions service.
@@ -77,8 +77,8 @@ type Service struct {
 	Volumes []string `yaml:"volumes,omitempty"`
 }
 
-// Step represents GitHub Actions step.
-type Step struct {
+// JobStep represents GitHub Actions job step.
+type JobStep struct {
 	Name            string            `yaml:"name"`
 	ID              string            `yaml:"id,omitempty"`
 	If              string            `yaml:"if,omitempty"`

--- a/internal/project/auto/builder.go
+++ b/internal/project/auto/builder.go
@@ -104,6 +104,10 @@ func (builder *builder) build() error {
 		}
 	}
 
+	if builder.meta.CompileGithubWorkflowsOnly {
+		return nil
+	}
+
 	if !mandatoryReached {
 		return errors.New("no Go or JS or Pkgfile files were found")
 	}

--- a/internal/project/auto/config.go
+++ b/internal/project/auto/config.go
@@ -36,6 +36,8 @@ type CustomStep struct {
 // CI defines CI settings.
 type CI struct {
 	Provider string `yaml:"provider"`
+	// CompileGHWorkflowsOnly is a flag to generate only GitHub Actions.
+	CompileGHWorkflowsOnly bool `yaml:"compileGHWorkflowsOnly"`
 }
 
 // CustomStepsGenerate defines custom steps that run before the build.

--- a/internal/project/common/build.go
+++ b/internal/project/common/build.go
@@ -66,12 +66,19 @@ func (build *Build) CompileMakefile(output *makefile.Output) error {
 		Variable(makefile.SimpleVariable("ABBREV_TAG", "$(shell git describe --tags >/dev/null 2>/dev/null && git describe --tag --always --match v[0-9]\\* --abbrev=0 || echo 'undefined')")).
 		Variable(makefile.SimpleVariable("BRANCH", "$(shell git rev-parse --abbrev-ref HEAD)")).
 		Variable(makefile.SimpleVariable("ARTIFACTS", build.ArtifactsPath)).
-		Variable(makefile.OverridableVariable("IMAGE_TAG", "$(TAG)"))
+		Variable(makefile.OverridableVariable("IMAGE_TAG", "$(TAG)")).
+		Variable(makefile.SimpleVariable("OPERATING_SYSTEM", "$(shell uname -s | tr '[:upper:]' '[:lower:]')")).
+		Variable(makefile.SimpleVariable("GOARCH", "$(shell uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')")).
+		Variable(makefile.SimpleVariable("SOURCE_DATE_EPOCH", "$(shell git log -1 --pretty=%ct)"))
 
 	if build.meta.ContainerImageFrontend == config.ContainerImageFrontendDockerfile {
 		variableGroup.Variable(makefile.OverridableVariable("WITH_DEBUG", "false")).
 			Variable(makefile.OverridableVariable("WITH_RACE", "false"))
 	}
+
+	output.Target("$(ARTIFACTS)").
+		Description("Creates artifacts directory.").
+		Script("@mkdir -p $(ARTIFACTS)")
 
 	output.Target("clean").
 		Description("Cleans up all artifacts.").

--- a/internal/project/common/gh_workflow.go
+++ b/internal/project/common/gh_workflow.go
@@ -1,0 +1,387 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package common
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/siderolabs/gen/xslices"
+
+	"github.com/siderolabs/kres/internal/config"
+	"github.com/siderolabs/kres/internal/dag"
+	"github.com/siderolabs/kres/internal/output/ghworkflow"
+	"github.com/siderolabs/kres/internal/project/meta"
+)
+
+// Job defines options for jobs.
+type Job struct {
+	Name          string   `yaml:"name"`
+	Conditions    []string `yaml:"conditions,omitempty"`
+	Crons         []string `yaml:"crons,omitempty"`
+	Depends       []string `yaml:"depends,omitempty"`
+	Runners       []string `yaml:"runners,omitempty"`
+	TriggerLabels []string `yaml:"triggerLabels,omitempty"`
+	Steps         []Step   `yaml:"steps,omitempty"`
+	SOPS          bool     `yaml:"sops"`
+	SetupBuildx   bool     `yaml:"setupBuildx"`
+}
+
+// Step defines options for steps.
+type Step struct { //nolint:govet
+	Name              string             `yaml:"name"`
+	Command           string             `yaml:"command"`
+	NonMakeStep       bool               `yaml:"nonMakeStep,omitempty"`
+	ArtifactStep      *ArtifactStep      `yaml:"artifactStep,omitempty"`
+	CheckoutStep      *CheckoutStep      `yaml:"checkoutStep,omitempty"`
+	CoverageStep      *CoverageStep      `yaml:"coverageStep,omitempty"`
+	TerraformStep     bool               `yaml:"terraformStep,omitempty"`
+	RegistryLoginStep *RegistryLoginStep `yaml:"registryLoginStep,omitempty"`
+	ReleaseStep       *ReleaseStep       `yaml:"releaseStep,omitempty"`
+	WithSudo          bool               `yaml:"withSudo,omitempty"`
+	Arguments         []string           `yaml:"arguments,omitempty"`
+	Environment       map[string]string  `yaml:"environment"`
+	TimeoutMinutes    int                `yaml:"timeoutMinutes,omitempty"`
+	ContinueOnError   bool               `yaml:"continueOnError,omitempty"`
+	Conditions        []string           `yaml:"conditions,omitempty"`
+}
+
+// ArtifactStep defines options for artifact steps.
+type ArtifactStep struct {
+	Type                string   `yaml:"type"`
+	ArtifactPath        string   `yaml:"artifactPath"`
+	AdditionalArtifacts []string `yaml:"additionalArtifacts,omitempty"`
+}
+
+// CheckoutStep defines options for checkout steps.
+type CheckoutStep struct {
+	Repository string `yaml:"repository"`
+	Ref        string `yaml:"ref"`
+	Path       string `yaml:"path"`
+}
+
+// CoverageStep defines options for coverage steps.
+type CoverageStep struct {
+	Files []string `yaml:"files"`
+}
+
+// ReleaseStep defines options for release steps.
+type ReleaseStep struct {
+	BaseDirectory     string   `yaml:"baseDirectory"`
+	ReleaseNotes      string   `yaml:"releaseNotes"`
+	Artifacts         []string `yaml:"artifacts"`
+	GenerateChecksums bool     `yaml:"generateChecksums"`
+}
+
+// RegistryLoginStep defines options for registry login steps.
+type RegistryLoginStep struct {
+	Registry string `yaml:"registry"`
+}
+
+// GHWorkflow is a node that represents the GitHub workflow configuration.
+type GHWorkflow struct {
+	dag.BaseNode
+
+	meta *meta.Options
+
+	Jobs []Job `yaml:"jobs"`
+}
+
+// NewGHWorkflow creates a new GHWorkflow node.
+func NewGHWorkflow(meta *meta.Options) *GHWorkflow {
+	return &GHWorkflow{
+		BaseNode: dag.NewBaseNode("ghworkflow"),
+
+		meta: meta,
+	}
+}
+
+// CompileGitHubWorkflow implements ghworkflow.Compiler.
+//
+//nolint:gocognit,gocyclo,cyclop,maintidx
+func (gh *GHWorkflow) CompileGitHubWorkflow(o *ghworkflow.Output) error {
+	touchedJobs := make(map[string]struct{})
+
+	for _, job := range gh.Jobs {
+		jobDef := &ghworkflow.Job{
+			If:          ghworkflow.DefaultSkipCondition,
+			RunsOn:      job.Runners,
+			Permissions: ghworkflow.DefaultJobPermissions(),
+			Needs:       job.Depends,
+			Steps:       ghworkflow.CommonSteps(),
+		}
+
+		if err := jobDef.SetConditions(job.Conditions...); err != nil {
+			return err
+		}
+
+		if job.SetupBuildx {
+			jobDef.Services = ghworkflow.DefaultServices()
+
+			jobDef.Steps = ghworkflow.DefaultSteps()
+		}
+
+		if job.SOPS {
+			jobDef.Steps = append(jobDef.Steps, ghworkflow.SOPSSteps()...)
+		}
+
+		for _, step := range job.Steps {
+			if step.ArtifactStep != nil {
+				var steps []*ghworkflow.JobStep
+
+				switch step.ArtifactStep.Type {
+				case "upload":
+					saveArtifactsStep := ghworkflow.Step("save artifacts").
+						SetUses("actions/upload-artifact@"+config.UploadArtifactActionVersion).
+						SetWith("name", "artifacts").
+						SetWith("path", step.ArtifactStep.ArtifactPath+"\n"+strings.Join(step.ArtifactStep.AdditionalArtifacts, "\n")).
+						SetWith("retention-days", "5")
+
+					if step.ContinueOnError {
+						saveArtifactsStep.SetContinueOnError()
+					}
+
+					steps = []*ghworkflow.JobStep{
+						ghworkflow.Step("Generate executable list").
+							SetCommand(fmt.Sprintf("find %s -type f -executable > %s/executable-artifacts", step.ArtifactStep.ArtifactPath, step.ArtifactStep.ArtifactPath)),
+						saveArtifactsStep,
+					}
+				case "download":
+					steps = []*ghworkflow.JobStep{
+						ghworkflow.Step("Download artifacts").
+							SetUses("actions/download-artifact@"+config.DownloadArtifactActionVersion).
+							SetWith("name", "artifacts").
+							SetWith("path", step.ArtifactStep.ArtifactPath),
+						ghworkflow.Step("Fix artifact permissions").
+							SetCommand(fmt.Sprintf("xargs -a %s/executable-artifacts -I {} chmod +x {}", step.ArtifactStep.ArtifactPath)),
+					}
+				default:
+					return fmt.Errorf("unknown artifact step type: %s", step.ArtifactStep.Type)
+				}
+
+				jobDef.Steps = append(jobDef.Steps, steps...)
+
+				continue
+			}
+
+			if step.CheckoutStep != nil {
+				checkoutStep := ghworkflow.Step(step.Name).
+					SetUses("actions/checkout@"+config.CheckOutActionVersion).
+					SetWith("repository", step.CheckoutStep.Repository).
+					SetWith("ref", step.CheckoutStep.Ref).
+					SetWith("path", step.CheckoutStep.Path)
+
+				jobDef.Steps = append(jobDef.Steps, checkoutStep)
+
+				continue
+			}
+
+			if step.CoverageStep != nil {
+				coverageStep := ghworkflow.Step(step.Name).
+					SetUses("codecov/codecov-action@"+config.CodeCovActionVersion).
+					SetWith("files", strings.Join(step.CoverageStep.Files, ",")).
+					SetWith("token", "${{ secrets.CODECOV_TOKEN }}").
+					SetTimeoutMinutes(step.TimeoutMinutes)
+
+				jobDef.Steps = append(jobDef.Steps, coverageStep)
+
+				continue
+			}
+
+			if step.TerraformStep {
+				terraformStep := ghworkflow.Step(step.Name).
+					SetUses("hashicorp/setup-terraform@"+config.SetupTerraformActionVersion).
+					SetWith("terraform_wrapper", "false")
+
+				jobDef.Steps = append(jobDef.Steps, terraformStep)
+
+				continue
+			}
+
+			if step.RegistryLoginStep != nil {
+				registryLoginStep := ghworkflow.Step(step.Name).
+					SetUses("docker/login-action@"+config.LoginActionVersion).
+					SetWith("registry", step.RegistryLoginStep.Registry)
+
+				if step.RegistryLoginStep.Registry == "ghcr.io" {
+					registryLoginStep.SetWith("username", "${{ github.repository_owner }}")
+					registryLoginStep.SetWith("password", "${{ secrets.GITHUB_TOKEN }}")
+				}
+
+				jobDef.Steps = append(jobDef.Steps, registryLoginStep)
+
+				continue
+			}
+
+			if step.ReleaseStep != nil {
+				artifacts := xslices.Map(step.ReleaseStep.Artifacts, func(artifact string) string {
+					return filepath.Join(step.ReleaseStep.BaseDirectory, artifact)
+				})
+
+				releaseStep := ghworkflow.Step(step.Name).
+					SetUses("crazy-max/ghaction-github-release@"+config.ReleaseActionVersion).
+					SetWith("body_path", filepath.Join(step.ReleaseStep.BaseDirectory, step.ReleaseStep.ReleaseNotes)).
+					SetWith("draft", "true").
+					SetWith("files", strings.Join(artifacts, "\n"))
+
+				if step.ReleaseStep.GenerateChecksums {
+					checkSumCommands := []string{
+						fmt.Sprintf("sha256sum %s > %s", strings.Join(artifacts, " "), filepath.Join(step.ReleaseStep.BaseDirectory, "sha256sum.txt")),
+						fmt.Sprintf("sha512sum %s > %s", strings.Join(artifacts, " "), filepath.Join(step.ReleaseStep.BaseDirectory, "sha512sum.txt")),
+					}
+
+					checkSumStep := ghworkflow.Step("Generate Checksums").
+						SetCommand(strings.Join(checkSumCommands, "\n"))
+
+					releaseStep.
+						SetWith("files", strings.Join(artifacts, "\n")+"\n"+filepath.Join(step.ReleaseStep.BaseDirectory, "sha*.txt"))
+
+					jobDef.Steps = append(jobDef.Steps, checkSumStep)
+				}
+
+				jobDef.Steps = append(jobDef.Steps, releaseStep)
+
+				continue
+			}
+
+			command := step.Command
+
+			stepDef := ghworkflow.Step(step.Name)
+
+			stepDef.SetTimeoutMinutes(step.TimeoutMinutes)
+
+			if step.ContinueOnError {
+				stepDef.SetContinueOnError()
+			}
+
+			if err := stepDef.SetConditions(step.Conditions...); err != nil {
+				return err
+			}
+
+			for k, v := range step.Environment {
+				stepDef.SetEnv(k, v)
+			}
+
+			if step.NonMakeStep {
+				if len(step.Arguments) > 0 {
+					command += " " + strings.Join(step.Arguments, "")
+				}
+
+				stepDef.SetCommand(command)
+
+				jobDef.Steps = append(jobDef.Steps, stepDef)
+
+				continue
+			}
+
+			if command == "" {
+				command = step.Name
+			}
+
+			stepDef.SetMakeStep(command, step.Arguments...)
+
+			if step.WithSudo {
+				stepDef.SetSudo()
+			}
+
+			jobDef.Steps = append(jobDef.Steps, stepDef)
+		}
+
+		if len(job.TriggerLabels) > 0 {
+			if len(job.Depends) < 1 {
+				return fmt.Errorf("job %s has triggerLabels but no depends", job.Name)
+			}
+
+			for _, dep := range job.Depends {
+				if _, ok := touchedJobs[dep]; !ok {
+					o.AddStep(dep,
+						ghworkflow.Step("Retrieve PR labels").
+							SetID("retrieve-pr-labels").
+							SetUses("actions/github-script@"+config.GitHubScriptActionVersion).
+							SetWith("retries", "3").
+							SetWith("script", strings.TrimPrefix(ghworkflow.IssueLabelRetrieveScript, "\n")),
+					)
+
+					o.AddOutputs(dep, map[string]string{
+						"labels": "${{ steps.retrieve-pr-labels.outputs.result }}",
+					})
+
+					touchedJobs[dep] = struct{}{}
+				}
+			}
+
+			conditions := xslices.Map(job.TriggerLabels, func(label string) string {
+				return fmt.Sprintf("contains(fromJSON(needs.default.outputs.labels), '%s')", label)
+			})
+
+			for range job.TriggerLabels {
+				jobDef.If = strings.Join(conditions, " || ")
+			}
+		}
+
+		if len(job.Crons) > 0 {
+			workflowName := job.Name + "-cron"
+
+			o.AddSlackNotify(workflowName)
+
+			o.AddWorkflow(
+				workflowName,
+				&ghworkflow.Workflow{
+					Name: workflowName,
+					// https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-a-fallback-value
+					Concurrency: ghworkflow.Concurrency{
+						Group:            "${{ github.head_ref || github.run_id }}",
+						CancelInProgress: true,
+					},
+					On: ghworkflow.On{
+						Schedule: xslices.Map(job.Crons, func(cron string) ghworkflow.Schedule {
+							return ghworkflow.Schedule{
+								Cron: cron,
+							}
+						}),
+					},
+					Jobs: map[string]*ghworkflow.Job{
+						"default": {
+							RunsOn:   job.Runners,
+							Services: ghworkflow.DefaultServices(),
+							Steps:    jobDef.Steps,
+						},
+					},
+				},
+			)
+
+			o.AddWorkflow(
+				workflowName,
+				&ghworkflow.Workflow{
+					Name: workflowName,
+					// https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-a-fallback-value
+					Concurrency: ghworkflow.Concurrency{
+						Group:            "${{ github.head_ref || github.run_id }}",
+						CancelInProgress: true,
+					},
+					On: ghworkflow.On{
+						Schedule: xslices.Map(job.Crons, func(cron string) ghworkflow.Schedule {
+							return ghworkflow.Schedule{
+								Cron: cron,
+							}
+						}),
+					},
+					Jobs: map[string]*ghworkflow.Job{
+						"default": {
+							RunsOn:   job.Runners,
+							Services: jobDef.Services,
+							Steps:    jobDef.Steps,
+						},
+					},
+				},
+			)
+		}
+
+		o.AddJob(job.Name, jobDef)
+	}
+
+	return nil
+}

--- a/internal/project/common/lint.go
+++ b/internal/project/common/lint.go
@@ -41,7 +41,7 @@ func (lint *Lint) CompileDrone(output *drone.Output) error {
 func (lint *Lint) CompileGitHubWorkflow(output *ghworkflow.Output) error {
 	output.AddStep(
 		"default",
-		ghworkflow.MakeStep("lint"),
+		ghworkflow.Step("lint").SetMakeStep("lint"),
 	)
 
 	return nil

--- a/internal/project/golang/build.go
+++ b/internal/project/golang/build.go
@@ -143,7 +143,7 @@ func (build *Build) CompileDrone(output *drone.Output) error {
 func (build *Build) CompileGitHubWorkflow(output *ghworkflow.Output) error {
 	output.AddStep(
 		"default",
-		ghworkflow.MakeStep(build.Name()),
+		ghworkflow.Step(build.Name()).SetMakeStep(build.Name()),
 	)
 
 	return nil

--- a/internal/project/golang/toolchain.go
+++ b/internal/project/golang/toolchain.go
@@ -183,7 +183,7 @@ func (toolchain *Toolchain) CompileDrone(output *drone.Output) error {
 
 // CompileGitHubWorkflow implements ghworkflow.Compiler.
 func (toolchain *Toolchain) CompileGitHubWorkflow(output *ghworkflow.Output) error {
-	output.AddStep("default", ghworkflow.MakeStep("base"))
+	output.AddStep("default", ghworkflow.Step("base").SetMakeStep("base"))
 
 	return nil
 }

--- a/internal/project/golang/unit_tests.go
+++ b/internal/project/golang/unit_tests.go
@@ -182,8 +182,8 @@ func (tests *UnitTests) CompileDrone(output *drone.Output) error {
 func (tests *UnitTests) CompileGitHubWorkflow(output *ghworkflow.Output) error {
 	output.AddStep(
 		"default",
-		ghworkflow.MakeStep(tests.Name()),
-		ghworkflow.MakeStep(tests.Name()+"-race"),
+		ghworkflow.Step(tests.Name()).SetMakeStep(tests.Name()),
+		ghworkflow.Step(tests.Name()+"-race").SetMakeStep(tests.Name()+"-race"),
 	)
 
 	return nil

--- a/internal/project/js/build.go
+++ b/internal/project/js/build.go
@@ -93,7 +93,7 @@ func (build *Build) CompileDrone(output *drone.Output) error {
 
 // CompileGitHubWorkflow implements ghworkflow.Compiler.
 func (build *Build) CompileGitHubWorkflow(output *ghworkflow.Output) error {
-	output.AddStep("default", ghworkflow.MakeStep(build.Name()))
+	output.AddStep("default", ghworkflow.Step(build.Name()).SetMakeStep(build.Name()))
 
 	return nil
 }

--- a/internal/project/js/toolchain.go
+++ b/internal/project/js/toolchain.go
@@ -106,7 +106,7 @@ func (toolchain *Toolchain) CompileDrone(output *drone.Output) error {
 
 // CompileGitHubWorkflow implements ghworkflow.Compiler.
 func (toolchain *Toolchain) CompileGitHubWorkflow(output *ghworkflow.Output) error {
-	output.AddStep("default", ghworkflow.MakeStep("js"))
+	output.AddStep("default", ghworkflow.Step("js").SetMakeStep("js"))
 
 	return nil
 }

--- a/internal/project/js/unit_tests.go
+++ b/internal/project/js/unit_tests.go
@@ -67,7 +67,7 @@ func (tests *UnitTests) CompileDrone(output *drone.Output) error {
 func (tests *UnitTests) CompileGitHubWorkflow(output *ghworkflow.Output) error {
 	output.AddStep(
 		"default",
-		ghworkflow.MakeStep(tests.Name()),
+		ghworkflow.Step(tests.Name()).SetMakeStep(tests.Name()),
 	)
 
 	return nil

--- a/internal/project/meta/meta.go
+++ b/internal/project/meta/meta.go
@@ -86,6 +86,8 @@ type Options struct { //nolint:govet
 	// CIProvider specifies the CI provider. Currently drone/ghaction is supported.
 	CIProvider string
 
+	CompileGithubWorkflowsOnly bool
+
 	// ContainerImageFrontend is the default frontend container image.
 	ContainerImageFrontend string
 }

--- a/internal/project/service/codecov.go
+++ b/internal/project/service/codecov.go
@@ -68,15 +68,11 @@ func (coverage *CodeCov) CompileGitHubWorkflow(output *ghworkflow.Output) error 
 
 	output.AddStep(
 		"default",
-		&ghworkflow.Step{
-			Name: "coverage",
-			Uses: fmt.Sprintf("codecov/codecov-action@%s", config.CodeCovActionVersion),
-			With: map[string]string{
-				"files": strings.Join(paths, ","),
-				"token": "${{ secrets.CODECOV_TOKEN }}",
-			},
-			TimeoutMinutes: 3,
-		},
+		ghworkflow.Step("coverage").
+			SetUses(fmt.Sprintf("codecov/codecov-action@%s", config.CodeCovActionVersion)).
+			SetWith("files", strings.Join(paths, ",")).
+			SetWith("token", "${{ secrets.CODECOV_TOKEN }}").
+			SetTimeoutMinutes(3),
 	)
 
 	return nil


### PR DESCRIPTION
Support managing only GitHub workflows.
This still handles SOPS, conform and repository checks.
Can be enabled with:

```yaml
---
kind: auto.CI
spec:
  compileGHWorkflowsOnly: true
```

Signed-off-by: Noel Georgi <git@frezbo.dev>