### PR TITLE
fix: source date epoch value.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-17T13:09:55Z by kres f04fa9c.
+# Generated on 2024-05-19T09:30:04Z by kres cba521d-dirty.
 
 # common variables
 
@@ -12,7 +12,6 @@ ARTIFACTS := _out
 IMAGE_TAG ?= $(TAG)
 OPERATING_SYSTEM := $(shell uname -s | tr '[:upper:]' '[:lower:]')
 GOARCH := $(shell uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')
-SOURCE_DATE_EPOCH := $(shell git log -1 --pretty=%ct)
 WITH_DEBUG ?= false
 WITH_RACE ?= false
 REGISTRY ?= ghcr.io

--- a/internal/project/common/build.go
+++ b/internal/project/common/build.go
@@ -68,8 +68,7 @@ func (build *Build) CompileMakefile(output *makefile.Output) error {
 		Variable(makefile.SimpleVariable("ARTIFACTS", build.ArtifactsPath)).
 		Variable(makefile.OverridableVariable("IMAGE_TAG", "$(TAG)")).
 		Variable(makefile.SimpleVariable("OPERATING_SYSTEM", "$(shell uname -s | tr '[:upper:]' '[:lower:]')")).
-		Variable(makefile.SimpleVariable("GOARCH", "$(shell uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')")).
-		Variable(makefile.SimpleVariable("SOURCE_DATE_EPOCH", "$(shell git log -1 --pretty=%ct)"))
+		Variable(makefile.SimpleVariable("GOARCH", "$(shell uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')"))
 
 	if build.meta.ContainerImageFrontend == config.ContainerImageFrontendDockerfile {
 		variableGroup.Variable(makefile.OverridableVariable("WITH_DEBUG", "false")).

--- a/internal/project/pkgfile/build.go
+++ b/internal/project/pkgfile/build.go
@@ -70,6 +70,10 @@ func (pkgfile *Build) CompileDockerignore(output *dockerignore.Output) error {
 
 // CompileMakefile implements makefile.Compiler.
 func (pkgfile *Build) CompileMakefile(output *makefile.Output) error {
+	output.VariableGroup(makefile.VariableGroupSourceDateEpoch).
+		Variable(makefile.SimpleVariable("INITIAL_COMMIT_SHA", "$(shell git rev-list --max-parents=0 HEAD)")).
+		Variable(makefile.SimpleVariable("SOURCE_DATE_EPOCH", "$(shell git log $(INITIAL_COMMIT_SHA) --pretty=%ct)"))
+
 	output.VariableGroup("sync bldr image with pkgfile").
 		Variable(makefile.SimpleVariable("BLDR_RELEASE", config.BldrImageVersion)).
 		Variable(makefile.SimpleVariable("BLDR_IMAGE", "ghcr.io/siderolabs/bldr:$(BLDR_RELEASE)")).


### PR DESCRIPTION
`SOURCE_DATE_EPOCH` is only used by `Pkgfile` based projects and it has to be a consistent value for easy reproducibility.