### PR TITLE
chore: use existing amd64 buildx

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-14T08:19:55Z by kres f0912c5-dirty.
+# Generated on 2024-05-20T15:59:05Z by kres 760d739-dirty.
 
 name: default
 concurrency:
@@ -29,15 +29,6 @@ jobs:
       - self-hosted
       - generic
     if: (!startsWith(github.head_ref, 'renovate/') && !startsWith(github.head_ref, 'dependabot/'))
-    services:
-      buildkitd:
-        image: moby/buildkit:v0.13.2
-        options: --privileged
-        ports:
-          - 1234:1234
-        volumes:
-          - /var/lib/buildkit/${{ github.repository }}:/var/lib/buildkit
-          - /usr/etc/buildkit/buildkitd.toml:/etc/buildkit/buildkitd.toml
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -49,7 +40,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           driver: remote
-          endpoint: tcp://127.0.0.1:1234
+          endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
         timeout-minutes: 10
       - name: base
         run: |

--- a/internal/project/auto/ci.go
+++ b/internal/project/auto/ci.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/siderolabs/kres/internal/config"
+	"github.com/siderolabs/kres/internal/dag"
 	"github.com/siderolabs/kres/internal/project/common"
 )
 
@@ -38,13 +39,16 @@ func (builder *builder) DetectCI() (bool, error) {
 
 // BuildCI builds the ci settings.
 func (builder *builder) BuildCI() error {
-	if builder.meta.CompileGithubWorkflowsOnly {
-		repository := common.NewRepository(builder.meta)
-		sops := common.NewSOPS(builder.meta)
-		ghworkflow := common.NewGHWorkflow(builder.meta)
+	var targets []dag.Node
 
-		builder.proj.AddTarget(repository, sops, ghworkflow)
+	targets = append(targets, common.NewGHWorkflow(builder.meta))
+
+	if builder.meta.CompileGithubWorkflowsOnly {
+		targets = append(targets, common.NewRepository(builder.meta))
+		targets = append(targets, common.NewSOPS(builder.meta))
 	}
+
+	builder.proj.AddTarget(targets...)
 
 	return nil
 }

--- a/internal/project/auto/config.go
+++ b/internal/project/auto/config.go
@@ -39,6 +39,3 @@ type CI struct {
 	// CompileGHWorkflowsOnly is a flag to generate only GitHub Actions.
 	CompileGHWorkflowsOnly bool `yaml:"compileGHWorkflowsOnly"`
 }
-
-// CustomStepsGenerate defines custom steps that run before the build.
-type CustomStepsGenerate = CustomSteps

--- a/internal/project/custom/custom.go
+++ b/internal/project/custom/custom.go
@@ -290,7 +290,7 @@ func (step *Step) DroneEnabled() bool {
 
 // CompileGitHubWorkflow implements ghworkflow.Compiler.
 //
-//nolint:gocognit,gocyclo,cyclop,maintidx
+//nolint:gocognit,gocyclo,cyclop
 func (step *Step) CompileGitHubWorkflow(output *ghworkflow.Output) error {
 	if !step.GHAction.Enabled {
 		return nil
@@ -413,11 +413,10 @@ func (step *Step) CompileGitHubWorkflow(output *ghworkflow.Output) error {
 		}
 
 		output.AddJob(job.Name, &ghworkflow.Job{
-			RunsOn:   append(runnerLabels, job.RunnerLabels...),
-			If:       strings.Join(conditions, " || "),
-			Needs:    []string{"default"},
-			Services: ghworkflow.DefaultServices(),
-			Steps:    defaultSteps,
+			RunsOn: append(runnerLabels, job.RunnerLabels...),
+			If:     strings.Join(conditions, " || "),
+			Needs:  []string{"default"},
+			Steps:  defaultSteps,
 		})
 
 		var steps []*ghworkflow.JobStep
@@ -491,8 +490,7 @@ func (step *Step) CompileGitHubWorkflow(output *ghworkflow.Output) error {
 					},
 					Jobs: map[string]*ghworkflow.Job{
 						"default": {
-							RunsOn:   append(runnerLabels, job.RunnerLabels...),
-							Services: ghworkflow.DefaultServices(),
+							RunsOn: append(runnerLabels, job.RunnerLabels...),
 							Steps: append(
 								defaultSteps,
 								steps...,

--- a/internal/project/pkgfile/build.go
+++ b/internal/project/pkgfile/build.go
@@ -177,8 +177,7 @@ func (pkgfile *Build) CompileMakefile(output *makefile.Output) error {
 
 // CompileGitHubWorkflow implements ghworkflow.Compiler.
 func (pkgfile *Build) CompileGitHubWorkflow(output *ghworkflow.Output) error {
-	output.SetDefaultJobRunnerAsPkgs()
-	output.OverwriteDefaultJobStepsAsPkgs()
+	output.SetOptionsForPkgs()
 
 	loginStep := ghworkflow.Step("Login to registry").
 		SetUses("docker/login-action@"+config.LoginActionVersion).


### PR DESCRIPTION
Use existing amd64 buildx runners.
Also support overriding default runners.