### PR TITLE
fix: enable sops step only for standard kres steps

### DIFF
--- a/internal/project/common/repository.go
+++ b/internal/project/common/repository.go
@@ -193,7 +193,9 @@ func (r *Repository) enableBranchProtection(client *github.Client) error {
 	case config.CIProviderDrone:
 		enforceContexts = append(enforceContexts, "continuous-integration/drone/pr")
 	case config.CIProviderGitHubActions:
-		enforceContexts = append(enforceContexts, "default")
+		if !r.meta.CompileGithubWorkflowsOnly {
+			enforceContexts = append(enforceContexts, "default")
+		}
 	}
 
 	if r.EnableConform {

--- a/internal/project/common/sops.go
+++ b/internal/project/common/sops.go
@@ -46,7 +46,8 @@ func (sops *SOPS) CompileSops(o *sops.Output) error {
 
 // CompileGitHubWorkflow implements ghworkflow.Compiler.
 func (sops *SOPS) CompileGitHubWorkflow(o *ghworkflow.Output) error {
-	if !sops.Enabled {
+	// If sops is disabled or we are only compiling github workflows (since sops can be optionally enabled there), return early.
+	if !sops.Enabled || sops.meta.CompileGithubWorkflowsOnly {
 		return nil
 	}
 


### PR DESCRIPTION
Only enable adding sops if it's a standard kres project, for github workflow managed by kres, it's part of job spec.