### PR TITLE
fix: go cross compile images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-20T11:14:33Z by kres dccd292-dirty.
+# Generated on 2024-05-23T10:13:37Z by kres 1ba3ec6-dirty.
 
 ARG TOOLCHAIN
 
@@ -20,7 +20,7 @@ COPY ./README.md ./README.md
 RUN markdownlint --ignore "CHANGELOG.md" --ignore "**/node_modules/**" --ignore '**/hack/chglog/**' --rules node_modules/sentences-per-line/index.js .
 
 # base toolchain image
-FROM ${TOOLCHAIN} AS toolchain
+FROM --platform=${BUILDPLATFORM} ${TOOLCHAIN} AS toolchain
 RUN apk --update --no-cache add bash curl build-base protoc protobuf-dev
 
 # build tools

--- a/internal/project/golang/toolchain.go
+++ b/internal/project/golang/toolchain.go
@@ -198,7 +198,7 @@ func (toolchain *Toolchain) CompileDockerfile(output *dockerfile.Output) error {
 
 	toolchainStage := output.Stage("toolchain").
 		Description("base toolchain image").
-		From("${TOOLCHAIN}")
+		From("--platform=${BUILDPLATFORM} ${TOOLCHAIN}")
 
 	if toolchain.Kind == ToolchainOfficial {
 		packages := []string{"add", "bash", "curl", "build-base", "protoc", "protobuf-dev"}


### PR DESCRIPTION
Set `BUILDPLATFROM` so that we re-use the toolchain.