### PR TITLE
fix: run verify as part of `npm ci` step

### DIFF
--- a/internal/project/js/toolchain.go
+++ b/internal/project/js/toolchain.go
@@ -145,7 +145,7 @@ func (toolchain *Toolchain) CompileDockerfile(output *dockerfile.Output) error {
 		Step(step.Copy(filepath.Join(toolchain.sourceDir, "package-lock.json"), "./")).
 		Step(step.Script("npm version ${VERSION}").
 			MountCache(toolchain.meta.NpmCachePath)).
-		Step(step.Script("npm ci").
+		Step(step.Script("npm ci && npm run verify").
 			MountCache(toolchain.meta.NpmCachePath)).
 		Step(step.Copy("frontend/.eslintrc.yaml", "./")).
 		Step(step.Copy(filepath.Join(toolchain.sourceDir, "babel.config.js"), "./")).


### PR DESCRIPTION
Verify can check that all required packages are installed and fail the step if something is missing so that it won't be cached.