### PR TITLE
chore: cleanup .golangci.yml

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-16T11:57:58Z by kres 48517a9-dirty.
+# Generated on 2024-05-28T08:10:29Z by kres 7e28d9f.
 
 # options for analysis running
 run:
@@ -13,8 +13,8 @@ run:
 # output configuration options
 output:
   formats:
-  - format: colored-line-number
-    path: stdout
+    - format: colored-line-number
+      path: stdout
   print-issued-lines: true
   print-linter-name: true
   uniq-by-line: true
@@ -94,17 +94,21 @@ linters-settings:
   cyclop:
     # the maximal code complexity to report
     max-complexity: 20
-  #  depguard:
-  #    Main:
-  #      deny:
-  #        - github.com/OpenPeeDeeP/depguard # this is just an example
+  depguard:
+    rules:
+      prevent_unmaintained_packages:
+        list-mode: lax # allow unless explicitely denied
+        files:
+          - $all
+        deny:
+          - pkg: io/ioutil
+            desc: "replaced by io and os packages since Go 1.16: https://tip.golang.org/doc/go1.16#ioutil"
 
 linters:
   enable-all: true
   disable-all: false
   fast: false
   disable:
-    - exhaustivestruct
     - exhaustruct
     - err113
     - forbidigo
@@ -120,30 +124,17 @@ linters:
     - mnd
     - nestif
     - nonamedreturns
-    - nosnakecase
     - paralleltest
     - tagalign
     - tagliatelle
     - thelper
-    - typecheck
     - varnamelen
     - wrapcheck
-    - depguard # Disabled because starting with golangci-lint 1.53.0 it doesn't allow denylist alone anymore
     - testifylint # complains about our assert recorder and has a number of false positives for assert.Greater(t, thing, 1)
     - protogetter # complains about us using Value field on typed spec, instead of GetValue which has a different signature
     - perfsprint # complains about us using fmt.Sprintf in non-performance critical code, updating just kres took too long
-    # abandoned linters for which golangci shows the warning that the repo is archived by the owner
-    - deadcode
-    - golint
-    - ifshort
-    - interfacer
-    - maligned
-    - scopelint
-    - structcheck
-    - varcheck
-    # disabled as it seems to be broken - goes into imported libraries and reports issues there
-    - musttag
     - goimports # same as gci
+    - musttag # seems to be broken - goes into imported libraries and reports issues there
 
 issues:
   exclude: [ ]

--- a/internal/output/golangci/golangci.yml
+++ b/internal/output/golangci/golangci.yml
@@ -9,8 +9,8 @@ run:
 # output configuration options
 output:
   formats:
-  - format: colored-line-number
-    path: stdout
+    - format: colored-line-number
+      path: stdout
   print-issued-lines: true
   print-linter-name: true
   uniq-by-line: true
@@ -90,17 +90,21 @@ linters-settings:
   cyclop:
     # the maximal code complexity to report
     max-complexity: 20
-  #  depguard:
-  #    Main:
-  #      deny:
-  #        - github.com/OpenPeeDeeP/depguard # this is just an example
+  depguard:
+    rules:
+      prevent_unmaintained_packages:
+        list-mode: lax # allow unless explicitly denied
+        files:
+          - $all
+        deny:
+          - pkg: io/ioutil
+            desc: "replaced by io and os packages since Go 1.16: https://tip.golang.org/doc/go1.16#ioutil"
 
 linters:
   enable-all: true
   disable-all: false
   fast: false
   disable:
-    - exhaustivestruct
     - exhaustruct
     - err113
     - forbidigo
@@ -116,30 +120,17 @@ linters:
     - mnd
     - nestif
     - nonamedreturns
-    - nosnakecase
     - paralleltest
     - tagalign
     - tagliatelle
     - thelper
-    - typecheck
     - varnamelen
     - wrapcheck
-    - depguard # Disabled because starting with golangci-lint 1.53.0 it doesn't allow denylist alone anymore
     - testifylint # complains about our assert recorder and has a number of false positives for assert.Greater(t, thing, 1)
     - protogetter # complains about us using Value field on typed spec, instead of GetValue which has a different signature
     - perfsprint # complains about us using fmt.Sprintf in non-performance critical code, updating just kres took too long
-    # abandoned linters for which golangci shows the warning that the repo is archived by the owner
-    - deadcode
-    - golint
-    - ifshort
-    - interfacer
-    - maligned
-    - scopelint
-    - structcheck
-    - varcheck
-    # disabled as it seems to be broken - goes into imported libraries and reports issues there
-    - musttag
     - goimports # same as gci
+    - musttag # seems to be broken - goes into imported libraries and reports issues there
 
 issues:
   exclude: [ ]

--- a/internal/project/common/repository.go
+++ b/internal/project/common/repository.go
@@ -23,7 +23,7 @@ import (
 )
 
 // Repository sets up repository settings.
-type Repository struct { //nolint:govet,maligned
+type Repository struct { //nolint:govet
 	dag.BaseNode
 
 	meta *meta.Options


### PR DESCRIPTION
- Add depguard back since it allows functionality similar to `denylist`.
- Remove fully deprecated and disabled linters from `linters.disable` section.