### PR TITLE
fix: remove `-g` flag from the bun install for the lint markdown step

### DIFF
--- a/internal/project/markdown/lint.go
+++ b/internal/project/markdown/lint.go
@@ -45,7 +45,7 @@ func (lint *Lint) CompileDockerfile(output *dockerfile.Output) error {
 	stage := output.Stage(lint.Name()).Description("runs markdownlint").
 		From("docker.io/oven/bun:" + lint.BaseImage).
 		Step(step.WorkDir("/src")).
-		Step(step.Run("bun", "i", "markdownlint-cli@"+lint.MardownLintCLIVersion, "sentences-per-line@"+lint.SentencesPerLineVersion, "-g")).
+		Step(step.Run("bun", "i", "markdownlint-cli@"+lint.MardownLintCLIVersion, "sentences-per-line@"+lint.SentencesPerLineVersion)).
 		Step(step.Copy(".markdownlint.json", "."))
 
 	for _, directory := range lint.meta.MarkdownDirectories {


### PR DESCRIPTION
It works without it, while adding this flag breaks it.