### PR TITLE
feat: allow additional `depguard` golangci-lint rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-29T17:36:13Z by kres a914cae-dirty.
+# Generated on 2024-06-19T18:39:17Z by kres 661b038.
 
 # options for analysis running
 run:
@@ -103,6 +103,20 @@ linters-settings:
         deny:
           - pkg: io/ioutil
             desc: "replaced by io and os packages since Go 1.16: https://tip.golang.org/doc/go1.16#ioutil"
+      test_kres_depguard_extra_rule_1:
+        deny:
+          - desc: Test rule 1
+            pkg: io/ioutil
+        files:
+          - test_1.go
+        list-mode: lax
+      test_kres_depguard_extra_rule_2:
+        deny:
+          - desc: Test rule 2
+            pkg: io/ioutil
+        files:
+          - test_2.go
+        list-mode: lax
 
 linters:
   enable-all: true

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -15,9 +15,9 @@
 kind: common.Image
 name: image-kres
 spec:
-    extraEnvironment:
-      PLATFORM: linux/amd64,linux/arm64
-    entrypointArgs: ['gen']
+  extraEnvironment:
+    PLATFORM: linux/amd64,linux/arm64
+  entrypointArgs: ['gen']
 ---
 kind: golang.Build
 spec:
@@ -37,13 +37,31 @@ spec:
 ---
 kind: service.CodeCov
 spec:
-    targetThreshold: 8
+  targetThreshold: 8
 ---
 kind: common.Build
 spec:
-    ignoredPaths:
-        - "_out/example/"
+  ignoredPaths:
+    - "_out/example/"
 ---
 kind: golang.Generate
 spec:
-    versionPackagePath: internal/version
+  versionPackagePath: internal/version
+---
+kind: golang.GolangciLint
+spec:
+  depguardExtraRules:
+    test_kres_depguard_extra_rule_1:
+      list-mode: lax
+      files:
+        - test_1.go
+      deny:
+        - pkg: io/ioutil
+          desc: Test rule 1
+    test_kres_depguard_extra_rule_2:
+      list-mode: lax
+      files:
+        - test_2.go
+      deny:
+        - pkg: io/ioutil
+          desc: Test rule 2

--- a/internal/output/golangci/golangci.yml
+++ b/internal/output/golangci/golangci.yml
@@ -99,7 +99,7 @@ linters-settings:
         deny:
           - pkg: io/ioutil
             desc: "replaced by io and os packages since Go 1.16: https://tip.golang.org/doc/go1.16#ioutil"
-
+{{ .DepguardExtraRules }}
 linters:
   enable-all: true
   disable-all: false

--- a/internal/project/golang/golangcilint.go
+++ b/internal/project/golang/golangcilint.go
@@ -22,6 +22,8 @@ type GolangciLint struct {
 
 	meta *meta.Options
 
+	DepguardExtraRules map[string]any `yaml:"depguardExtraRules"`
+
 	Version     string
 	projectPath string
 }
@@ -43,6 +45,7 @@ func NewGolangciLint(meta *meta.Options, projectPath string) *GolangciLint {
 // CompileGolangci implements golangci.Compiler.
 func (lint *GolangciLint) CompileGolangci(output *golangci.Output) error {
 	output.Enable()
+	output.SetDepguardExtraRules(lint.DepguardExtraRules)
 	output.NewFile(lint.projectPath)
 
 	return nil


### PR DESCRIPTION
Allow projects to define additional `depguard` rules in their `.kres.yaml`.

To be used by https://github.com/siderolabs/omni/issues/373.