### PR TITLE
chore: pkgfile skip build on merges.

### DIFF
--- a/internal/project/pkgfile/build.go
+++ b/internal/project/pkgfile/build.go
@@ -195,9 +195,15 @@ func (pkgfile *Build) CompileGitHubWorkflow(output *ghworkflow.Output) error {
 		return err
 	}
 
+	buildStep := ghworkflow.Step("Build").SetMakeStep("")
+
+	if err := buildStep.SetConditions("on-pull-request"); err != nil {
+		return err
+	}
+
 	output.AddStep(
 		"default",
-		ghworkflow.Step("Build").SetMakeStep(""),
+		buildStep,
 	)
 
 	steps := []*ghworkflow.JobStep{


### PR DESCRIPTION
Skip building again on PR merges for `Pkgfile` based repos, this should force it to re-use cache if available.