### PR TITLE
feat: make release script portable

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-08-27T16:16:08Z by kres 8e4bbb4-dirty.
+# Generated on 2024-08-28T15:19:26Z by kres 0b55936-dirty.
 
 set -e
 

--- a/internal/output/files.go
+++ b/internal/output/files.go
@@ -144,6 +144,11 @@ func splitIgnoringPreamble(r io.Reader) ([]string, error) {
 			contents = append(contents, line)
 		}
 
+		// `#!` is a shebang and not preamble
+		if strings.HasPrefix(line, "#!") {
+			contents = append(contents, line)
+		}
+
 		if inPreamble && (stringContainsPreamble(line, comments...) || line == "" || line == "---") {
 			continue
 		}

--- a/internal/output/release/release.go
+++ b/internal/output/release/release.go
@@ -82,7 +82,7 @@ func (o *Output) Permissions(filename string) os.FileMode {
 }
 
 func (o *Output) releaseScript(w io.Writer) error {
-	if _, err := w.Write([]byte("#!/bin/bash\n\n")); err != nil {
+	if _, err := w.Write([]byte("#!/usr/bin/env bash\n\n")); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Ensures the hack/release.sh script is more portable by using the /usr/bin/env shebang.