### PR TITLE
fix: fix local artifact output locations when `BUILDKIT_MULTI_PLATFORM=1`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-11-05T11:16:22Z by kres 5fa0b38-dirty.
+# Generated on 2024-11-06T12:40:22Z by kres 1becf29d-dirty.
 
 # common variables
 
@@ -146,6 +146,15 @@ target-%:  ## Builds the specified target defined in the Dockerfile. The build r
 
 local-%:  ## Builds the specified target defined in the Dockerfile using the local output type. The build result will be output to the specified local destination.
 	@$(MAKE) target-$* TARGET_ARGS="--output=type=local,dest=$(DEST) $(TARGET_ARGS)"
+	@PLATFORM=$(PLATFORM) ARTIFACTS=$(ARTIFACTS) bash -c '\
+	  for platform in $$(tr "," "\n" <<< "$$PLATFORM"); do \
+	    echo $$platform; \
+	    directory="$${platform//\//_}"; \
+	    if [[ -d "$$ARTIFACTS/$$directory" ]]; then \
+	      mv "$$ARTIFACTS/$$directory/"* $$ARTIFACTS; \
+	      rmdir "$$ARTIFACTS/$$directory/"; \
+	    fi; \
+	  done'
 
 generate:  ## Generate .proto definitions.
 	@$(MAKE) local-$@ DEST=./

--- a/internal/project/common/docker.go
+++ b/internal/project/common/docker.go
@@ -17,6 +17,25 @@ import (
 	"github.com/siderolabs/kres/internal/project/meta"
 )
 
+// FixLocalArtifactLocationsScript moves the local build artifacts from the <os>_<arch> subdirectories to the build output root directory.
+//
+// This is to revert the behavior of buildkit on multi-platform builds.
+//
+// As we force buildkit to always do multi-platform builds (via `BUILDKIT_MULTI_PLATFORM=1`), we need this fix to restore old output behavior.
+//
+// This script is appended to the local output build targets.
+const FixLocalArtifactLocationsScript = `
+@PLATFORM=$(PLATFORM) ARTIFACTS=$(ARTIFACTS) bash -c '\
+  for platform in $$(tr "," "\n" <<< "$$PLATFORM"); do \
+    echo $$platform; \
+    directory="$${platform//\//_}"; \
+    if [[ -d "$$ARTIFACTS/$$directory" ]]; then \
+      mv "$$ARTIFACTS/$$directory/"* $$ARTIFACTS; \
+      rmdir "$$ARTIFACTS/$$directory/"; \
+    fi; \
+  done'
+`
+
 // Docker provides build infrastructure via docker buildx.
 type Docker struct { //nolint:govet
 	dag.BaseNode
@@ -147,7 +166,7 @@ func (docker *Docker) CompileMakefile(output *makefile.Output) error {
 
 	output.Target("local-%").
 		Description("Builds the specified target defined in the Dockerfile using the local output type. The build result will be output to the specified local destination.").
-		Script(`@$(MAKE) target-$* TARGET_ARGS="--output=type=local,dest=$(DEST) $(TARGET_ARGS)"`)
+		Script(`@$(MAKE) target-$* TARGET_ARGS="--output=type=local,dest=$(DEST) $(TARGET_ARGS)"` + FixLocalArtifactLocationsScript)
 
 	return nil
 }

--- a/internal/project/pkgfile/build.go
+++ b/internal/project/pkgfile/build.go
@@ -14,6 +14,7 @@ import (
 	"github.com/siderolabs/kres/internal/output/dockerignore"
 	"github.com/siderolabs/kres/internal/output/ghworkflow"
 	"github.com/siderolabs/kres/internal/output/makefile"
+	"github.com/siderolabs/kres/internal/project/common"
 	"github.com/siderolabs/kres/internal/project/meta"
 )
 
@@ -114,7 +115,7 @@ func (pkgfile *Build) CompileMakefile(output *makefile.Output) error {
 
 	output.Target("local-%").
 		Description("Builds the specified target defined in the Pkgfile using the local output type. The build result will be output to the specified local destination.").
-		Script(`@$(MAKE) target-$* TARGET_ARGS="--output=type=local,dest=$(DEST) $(TARGET_ARGS)"`)
+		Script(`@$(MAKE) target-$* TARGET_ARGS="--output=type=local,dest=$(DEST) $(TARGET_ARGS)"` + common.FixLocalArtifactLocationsScript)
 
 	output.Target("docker-%").
 		Description("Builds the specified target defined in the Pkgfile using the docker output type. The build result will be loaded into Docker.").


### PR DESCRIPTION
Passing `BUILDKIT_MULTI_PLATFORM=1` to buildkit for each build (introduced in https://github.com/siderolabs/kres/commit/7db4f5e2647e1bbccf6915ff3d84a0754e1b5057) in `COMMON_ARGS` caused some unwanted changes in the output behavior when we ran a single-platform build: it started to output the files to locations same as to multi-platform format, `<os>_<arch>/<filename>`, instead of just `<filename>`.

Fix this by running a small script to move these files to one upper directory after a local build.