### PR TITLE
fix: fix `make generate` to build with `BUILDKIT_MULTI_PLATFORM=0`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-06-19T18:39:17Z by kres 661b038.
+# Generated on 2024-11-14T12:41:15Z by kres 192a4d9c.
 
 # options for analysis running
 run:
@@ -130,7 +130,6 @@ linters:
     - gochecknoglobals
     - gochecknoinits
     - godox
-    - gomnd
     - gomoddirectives
     - gosec
     - inamedparam

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-11-12T14:20:31Z by kres b6443eb-dirty.
+# Generated on 2024-11-15T09:12:52Z by kres c89d4488.
 
 # common variables
 
@@ -157,7 +157,7 @@ local-%:  ## Builds the specified target defined in the Dockerfile using the loc
 	  done'
 
 generate:  ## Generate .proto definitions.
-	@$(MAKE) local-$@ DEST=./
+	@$(MAKE) local-$@ TARGET_ARGS="--build-arg=BUILDKIT_MULTI_PLATFORM=0 $(TARGET_ARGS)" DEST=./
 
 lint-golangci-lint:  ## Runs golangci-lint linter.
 	@$(MAKE) target-$@

--- a/internal/output/golangci/golangci.yml
+++ b/internal/output/golangci/golangci.yml
@@ -112,7 +112,6 @@ linters:
     - gochecknoglobals
     - gochecknoinits
     - godox
-    - gomnd
     - gomoddirectives
     - gosec
     - inamedparam

--- a/internal/project/golang/generate.go
+++ b/internal/project/golang/generate.go
@@ -117,7 +117,7 @@ func (generate *Generate) CompileMakefile(output *makefile.Output) error {
 	}
 
 	output.Target("generate").Description("Generate .proto definitions.").
-		Script("@$(MAKE) local-$@ DEST=./")
+		Script(`@$(MAKE) local-$@ TARGET_ARGS="--build-arg=BUILDKIT_MULTI_PLATFORM=0 $(TARGET_ARGS)" DEST=./`)
 
 	return nil
 }


### PR DESCRIPTION
Due to the change in `BUILDKIT_MULTI_PLATFORM=1`, the generated files from `make generate` land initially in a directory named `<os>_<arch>`, which we then move into the actual destination directories with a script.

This move fails to merge the existing directories with the newly generated files. So, instead, on `generate` command, we override the `BUILDKIT_MULTI_PLATFORM` variable back to `0` to restore the old behavior. We do not need it for generating sources.

Additionally, remove the deprecated `gomnd` linter from the `golangci-lint` configuration.