### PR TITLE
fix: make `BULDKIT_MULTIPLATFORM` a make variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-11-15T09:12:52Z by kres c89d4488.
+# Generated on 2024-11-18T15:07:30Z by kres 91b35db-dirty.
 
 # common variables
 
@@ -41,12 +41,13 @@ PLATFORM ?= linux/amd64
 PROGRESS ?= auto
 PUSH ?= false
 CI_ARGS ?=
+BUILDKIT_MULTI_PLATFORM ?= 1
 COMMON_ARGS = --file=Dockerfile
 COMMON_ARGS += --provenance=false
 COMMON_ARGS += --progress=$(PROGRESS)
 COMMON_ARGS += --platform=$(PLATFORM)
 COMMON_ARGS += --push=$(PUSH)
-COMMON_ARGS += --build-arg=BUILDKIT_MULTI_PLATFORM=1
+COMMON_ARGS += --build-arg=BUILDKIT_MULTI_PLATFORM=$(BUILDKIT_MULTI_PLATFORM)
 COMMON_ARGS += --build-arg=ARTIFACTS="$(ARTIFACTS)"
 COMMON_ARGS += --build-arg=SHA="$(SHA)"
 COMMON_ARGS += --build-arg=TAG="$(TAG)"
@@ -157,7 +158,7 @@ local-%:  ## Builds the specified target defined in the Dockerfile using the loc
 	  done'
 
 generate:  ## Generate .proto definitions.
-	@$(MAKE) local-$@ TARGET_ARGS="--build-arg=BUILDKIT_MULTI_PLATFORM=0 $(TARGET_ARGS)" DEST=./
+	@$(MAKE) local-$@ DEST=./ BUILDKIT_MULTI_PLATFORM=0
 
 lint-golangci-lint:  ## Runs golangci-lint linter.
 	@$(MAKE) target-$@

--- a/internal/project/common/docker.go
+++ b/internal/project/common/docker.go
@@ -137,7 +137,7 @@ func (docker *Docker) CompileMakefile(output *makefile.Output) error {
 		Push("--progress=$(PROGRESS)").
 		Push("--platform=$(PLATFORM)").
 		Push("--push=$(PUSH)").
-		Push("--build-arg=BUILDKIT_MULTI_PLATFORM=1")
+		Push("--build-arg=BUILDKIT_MULTI_PLATFORM=$(BUILDKIT_MULTI_PLATFORM)")
 
 	for _, arg := range docker.meta.BuildArgs {
 		buildArgs.Push(fmt.Sprintf("--build-arg=%s=\"$(%s)\"", arg, arg))
@@ -158,6 +158,7 @@ func (docker *Docker) CompileMakefile(output *makefile.Output) error {
 		Variable(makefile.OverridableVariable("PROGRESS", "auto")).
 		Variable(makefile.OverridableVariable("PUSH", "false")).
 		Variable(makefile.OverridableVariable("CI_ARGS", "")).
+		Variable(makefile.OverridableVariable("BUILDKIT_MULTI_PLATFORM", "1")).
 		Variable(buildArgs)
 
 	output.Target("target-%").

--- a/internal/project/golang/generate.go
+++ b/internal/project/golang/generate.go
@@ -117,7 +117,7 @@ func (generate *Generate) CompileMakefile(output *makefile.Output) error {
 	}
 
 	output.Target("generate").Description("Generate .proto definitions.").
-		Script(`@$(MAKE) local-$@ TARGET_ARGS="--build-arg=BUILDKIT_MULTI_PLATFORM=0 $(TARGET_ARGS)" DEST=./`)
+		Script(`@$(MAKE) local-$@ DEST=./ BUILDKIT_MULTI_PLATFORM=0`)
 
 	return nil
 }

--- a/internal/project/pkgfile/build.go
+++ b/internal/project/pkgfile/build.go
@@ -85,7 +85,7 @@ func (pkgfile *Build) CompileMakefile(output *makefile.Output) error {
 		Push("--progress=$(PROGRESS)").
 		Push("--platform=$(PLATFORM)").
 		Push("--build-arg=SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH)").
-		Push("--build-arg=BUILDKIT_MULTI_PLATFORM=1")
+		Push("--build-arg=BUILDKIT_MULTI_PLATFORM=$(BUILDKIT_MULTI_PLATFORM)")
 
 	for _, arg := range pkgfile.ExtraBuildArgs {
 		buildArgs.Push(fmt.Sprintf("--build-arg=%s=\"$(%s)\"", arg, arg))
@@ -102,6 +102,7 @@ func (pkgfile *Build) CompileMakefile(output *makefile.Output) error {
 		Variable(makefile.OverridableVariable("PROGRESS", "auto")).
 		Variable(makefile.OverridableVariable("PUSH", "false")).
 		Variable(makefile.OverridableVariable("CI_ARGS", "")).
+		Variable(makefile.OverridableVariable("BUILDKIT_MULTI_PLATFORM", "1")).
 		Variable(buildArgs)
 
 	for _, arg := range pkgfile.Makefile.ExtraVariables {


### PR DESCRIPTION
This allows to properly override it on per-target basis.

This is required to fix kernel build in pkgs.