### PR TITLE
fix: disable `BUILDKIT_MULTI_PLATFORM` for JS protobuf generation

### DIFF
--- a/internal/project/js/protobuf.go
+++ b/internal/project/js/protobuf.go
@@ -76,7 +76,7 @@ func (proto *Protobuf) CompileMakefile(output *makefile.Output) error {
 
 	output.Target("generate-" + proto.Name()).
 		Description("Generate .proto definitions.").
-		Script("@$(MAKE) local-$@ DEST=./")
+		Script("@$(MAKE) local-$@ DEST=./ BUILDKIT_MULTI_PLATFORM=0")
 
 	return nil
 }


### PR DESCRIPTION
Same fix as in 91b35db66814d3687233e0eb5987e777210d795d, a8af16daf5f0d7c9a61d81218820de7f0c407f97, but for the JS definitions.