### PR TITLE
fix: renovate config option

### DIFF
--- a/internal/output/renovate/types.go
+++ b/internal/output/renovate/types.go
@@ -35,7 +35,7 @@ type PackageRule struct {
 	VersioningTemplate string `json:"versioningTemplate,omitempty"`
 
 	MatchDataSources []string `json:"matchDataSources,omitempty"`
-	MatchFiles       []string `json:"matchFiles,omitempty"`
+	MatchFileNames   []string `json:"matchFileNames,omitempty"`
 	MatchPaths       []string `json:"matchPaths,omitempty"`
 
 	MatchPackageNames []string `json:"matchPackageNames,omitempty"`

--- a/internal/project/common/renovate.go
+++ b/internal/project/common/renovate.go
@@ -38,7 +38,7 @@ type PackageRule struct {
 	Enabled           *bool    `yaml:"enabled,omitempty"`
 	Versioning        string   `yaml:"versioning,omitempty"`
 	MatchDataSources  []string `yaml:"matchDataSources,omitempty"`
-	MatchFiles        []string `yaml:"matchFiles,omitempty"`
+	MatchFileNames    []string `yaml:"matchFileNames,omitempty"`
 	MatchPaths        []string `yaml:"matchPaths,omitempty"`
 	MatchPackageNames []string `yaml:"matchPackageNames,omitempty"`
 }
@@ -75,7 +75,7 @@ func (r *Renovate) CompileRenovate(o *renovate.Output) error {
 		return renovate.PackageRule{
 			Enabled:           pr.Enabled,
 			MatchDataSources:  pr.MatchDataSources,
-			MatchFiles:        pr.MatchFiles,
+			MatchFileNames:    pr.MatchFileNames,
 			MatchPaths:        pr.MatchPaths,
 			MatchPackageNames: pr.MatchPackageNames,
 			Versioning:        pr.Versioning,


### PR DESCRIPTION
`matchFiles` is removed in favor of `matchFileNames`.