### PR TITLE
fix: don't add `COPY --from embed-generate` on no `version.go`

### DIFF
--- a/internal/output/golangci/golangci.go
+++ b/internal/output/golangci/golangci.go
@@ -128,8 +128,8 @@ func (o *Output) buildTemplateData() (golangciLintTemplateData, error) {
 		for line := range strings.Lines(sb.String()) {
 			if line != "" {
 				indented.WriteString("      ")
-				indented.WriteString(line)
-				indented.WriteString("\n")
+				indented.WriteString(strings.TrimRight(line, "\n")) // ensure no double newlines
+				indented.WriteByte('\n')
 			}
 		}
 

--- a/internal/project/auto/golang.go
+++ b/internal/project/auto/golang.go
@@ -177,11 +177,20 @@ func (builder *builder) processDirectory(path string) error {
 			exists, err := directoryExists(dir, candidate)
 			if err != nil {
 				return err
+			} else if !exists {
+				continue
 			}
 
-			if exists {
-				builder.meta.VersionPackagePath = filepath.Join(canonicalPath, filepath.Join(dir, candidate))
+			list, err := listFilesWithSuffix(filepath.Join(dir, candidate), ".go")
+			if err != nil {
+				return err
 			}
+
+			if len(list) == 0 || !slices.Contains(list, "version.go") {
+				continue
+			}
+
+			builder.meta.VersionPackagePath = filepath.Join(canonicalPath, filepath.Join(dir, candidate))
 		}
 	}
 


### PR DESCRIPTION
If `version.go` file doesn't exist, it doesn't make sense to add this directive.