### PR TITLE
chore: remove deprecated linter

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-02-23T02:18:49Z by kres 279c0a2-dirty.
+# Generated on 2025-02-24T10:54:07Z by kres c92d97e6.
 
 policies:
   - type: commit

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-01-15T10:00:52Z by kres d512b12a.
+# Generated on 2025-02-24T10:54:07Z by kres c92d97e6.
 
 # options for analysis running
 run:
@@ -147,7 +147,6 @@ linters:
     - perfsprint # complains about us using fmt.Sprintf in non-performance critical code, updating just kres took too long
     - goimports # same as gci
     - musttag # seems to be broken - goes into imported libraries and reports issues there
-    - exportloopref # WARN The linter 'exportloopref' is deprecated (since v1.60.2) due to: Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar.
 
 issues:
   exclude: [ ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-02-14T14:04:03Z by kres 2b55dd5-dirty.
+# Generated on 2025-02-24T10:54:07Z by kres c92d97e6.
 
 ARG TOOLCHAIN
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-02-13T16:33:14Z by kres e87569e.
+# Generated on 2025-02-24T10:54:07Z by kres c92d97e6.
 
 # common variables
 

--- a/internal/output/golangci/golangci.yml
+++ b/internal/output/golangci/golangci.yml
@@ -129,7 +129,6 @@ linters:
     - perfsprint # complains about us using fmt.Sprintf in non-performance critical code, updating just kres took too long
     - goimports # same as gci
     - musttag # seems to be broken - goes into imported libraries and reports issues there
-    - exportloopref # WARN The linter 'exportloopref' is deprecated (since v1.60.2) due to: Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar.
 
 issues:
   exclude: [ ]


### PR DESCRIPTION
The linter "exportloopref" is deprecated and deactivated. It should be removed from the list of disabled linters. https://golangci-lint.run/product/roadmap/#linter-deprecation-cycle

related: https://github.com/siderolabs/omni/pull/950