### PR TITLE
feat: unify buildkits

### DIFF
--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -19,9 +19,6 @@ const (
 	// renovate: datasource=github-releases depName=siderolabs/bldr
 	BldrImageVersion = "v0.4.1"
 
-	// BuildKitContainerVersion is the version of buildkit container image.
-	// renovate: datasource=docker versioning=docker depName=moby/buildkit
-	BuildKitContainerVersion = "v0.20.0"
 	// CheckOutActionVersion is the version of checkout github action.
 	// renovate: datasource=github-releases extractVersion=^(?<version>v\d+)\.\d+\.\d+$ depName=actions/checkout
 	CheckOutActionVersion = "v4"

--- a/internal/output/ghworkflow/gh_workflow.go
+++ b/internal/output/ghworkflow/gh_workflow.go
@@ -244,7 +244,6 @@ func (o *Output) SetOptionsForPkgs() {
 	o.SetRunners(HostedRunner, PkgsRunner)
 
 	o.workflows[ciWorkflow].Jobs["default"].Steps = DefaultPkgsSteps()
-	o.workflows[ciWorkflow].Jobs["default"].Services = DefaultServices()
 }
 
 // CommonSteps returns common steps for the workflow.
@@ -302,7 +301,7 @@ func DefaultPkgsSteps() []*JobStep {
 			Uses: "docker/setup-buildx-action@" + config.SetupBuildxActionVersion,
 			With: map[string]string{
 				"driver":   "remote",
-				"endpoint": "tcp://127.0.0.1:1234",
+				"endpoint": "tcp://buildkit-amd64.ci.svc.cluster.local:1234",
 				"append":   strings.TrimPrefix(armbuildkitdEnpointConfig, "\n"),
 			},
 		},
@@ -319,21 +318,6 @@ func SOPSSteps() []*JobStep {
 		{
 			Name: "Set secrets for job",
 			Run:  "sops -d .secrets.yaml | yq -e '.secrets | to_entries[] | .key + \"=\" + .value' >> \"$GITHUB_ENV\"\n",
-		},
-	}
-}
-
-// DefaultServices returns default services for the workflow.
-func DefaultServices() map[string]Service {
-	return map[string]Service{
-		"buildkitd": {
-			Image:   "moby/buildkit:" + config.BuildKitContainerVersion,
-			Options: "--privileged",
-			Ports:   []string{"1234:1234"},
-			Volumes: []string{
-				"/var/lib/buildkit/${{ github.repository }}:/var/lib/buildkit",
-				"/usr/etc/buildkit/buildkitd.toml:/etc/buildkit/buildkitd.toml",
-			},
 		},
 	}
 }

--- a/internal/project/common/gh_workflow.go
+++ b/internal/project/common/gh_workflow.go
@@ -138,7 +138,6 @@ func (gh *GHWorkflow) CompileGitHubWorkflow(o *ghworkflow.Output) error {
 			jobDef.Steps = ghworkflow.DefaultSteps()
 
 			if job.BuildxOptions.CrossBuilder {
-				jobDef.Services = ghworkflow.DefaultServices()
 				jobDef.Steps = ghworkflow.DefaultPkgsSteps()
 			}
 		}

--- a/internal/project/pkgfile/build.go
+++ b/internal/project/pkgfile/build.go
@@ -263,11 +263,10 @@ func (pkgfile *Build) CompileGitHubWorkflow(output *ghworkflow.Output) error {
 		}
 
 		output.AddJob("reproducibility", &ghworkflow.Job{
-			RunsOn:   runnerLabels,
-			If:       "contains(fromJSON(needs.default.outputs.labels), 'integration/reproducibility')",
-			Needs:    []string{"default"},
-			Services: ghworkflow.DefaultServices(),
-			Steps:    ghworkflow.DefaultPkgsSteps(),
+			RunsOn: runnerLabels,
+			If:     "contains(fromJSON(needs.default.outputs.labels), 'integration/reproducibility')",
+			Needs:  []string{"default"},
+			Steps:  ghworkflow.DefaultPkgsSteps(),
 		})
 		output.AddStep("reproducibility", ghworkflow.Step("reproducibility-test").SetMakeStep("reproducibility-test"))
 
@@ -290,8 +289,7 @@ func (pkgfile *Build) CompileGitHubWorkflow(output *ghworkflow.Output) error {
 				},
 				Jobs: map[string]*ghworkflow.Job{
 					"reproducibility": {
-						RunsOn:   runnerLabels,
-						Services: ghworkflow.DefaultServices(),
+						RunsOn: runnerLabels,
 						Steps: append(
 							ghworkflow.DefaultPkgsSteps(),
 							ghworkflow.Step("reproducibility-test").SetMakeStep("reproducibility-test"),


### PR DESCRIPTION
Use same buildkit for pkgs and other builds. Stop using sub-volumes for caches.