### PR TITLE
fix: use project-specific cache IDs per project

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-03-05T12:50:23Z by kres 30e7a85-dirty.
+# Generated on 2025-03-07T16:20:10Z by kres d88db2f-dirty.
 
 ARG TOOLCHAIN
 
@@ -33,12 +33,12 @@ ARG GOEXPERIMENT
 ENV GOEXPERIMENT=${GOEXPERIMENT}
 ENV GOPATH=/go
 ARG DEEPCOPY_VERSION
-RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg go install github.com/siderolabs/deep-copy@${DEEPCOPY_VERSION} \
+RUN --mount=type=cache,target=/root/.cache/go-build,id=kres/root/.cache/go-build --mount=type=cache,target=/go/pkg,id=kres/go/pkg go install github.com/siderolabs/deep-copy@${DEEPCOPY_VERSION} \
 	&& mv /go/bin/deep-copy /bin/deep-copy
 ARG GOLANGCILINT_VERSION
-RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg go install github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCILINT_VERSION} \
+RUN --mount=type=cache,target=/root/.cache/go-build,id=kres/root/.cache/go-build --mount=type=cache,target=/go/pkg,id=kres/go/pkg go install github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCILINT_VERSION} \
 	&& mv /go/bin/golangci-lint /bin/golangci-lint
-RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg go install golang.org/x/vuln/cmd/govulncheck@latest \
+RUN --mount=type=cache,target=/root/.cache/go-build,id=kres/root/.cache/go-build --mount=type=cache,target=/go/pkg,id=kres/go/pkg go install golang.org/x/vuln/cmd/govulncheck@latest \
 	&& mv /go/bin/govulncheck /bin/govulncheck
 ARG GOFUMPT_VERSION
 RUN go install mvdan.cc/gofumpt@${GOFUMPT_VERSION} \
@@ -50,11 +50,11 @@ WORKDIR /src
 COPY go.mod go.mod
 COPY go.sum go.sum
 RUN cd .
-RUN --mount=type=cache,target=/go/pkg go mod download
-RUN --mount=type=cache,target=/go/pkg go mod verify
+RUN --mount=type=cache,target=/go/pkg,id=kres/go/pkg go mod download
+RUN --mount=type=cache,target=/go/pkg,id=kres/go/pkg go mod verify
 COPY ./cmd ./cmd
 COPY ./internal ./internal
-RUN --mount=type=cache,target=/go/pkg go list -mod=readonly all >/dev/null
+RUN --mount=type=cache,target=/go/pkg,id=kres/go/pkg go list -mod=readonly all >/dev/null
 
 FROM tools AS embed-generate
 ARG SHA
@@ -74,24 +74,24 @@ WORKDIR /src
 COPY .golangci.yml .
 ENV GOGC=50
 RUN golangci-lint config verify --config .golangci.yml
-RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/root/.cache/golangci-lint --mount=type=cache,target=/go/pkg golangci-lint run --config .golangci.yml
+RUN --mount=type=cache,target=/root/.cache/go-build,id=kres/root/.cache/go-build --mount=type=cache,target=/root/.cache/golangci-lint,id=kres/root/.cache/golangci-lint,sharing=locked --mount=type=cache,target=/go/pkg,id=kres/go/pkg golangci-lint run --config .golangci.yml
 
 # runs govulncheck
 FROM base AS lint-govulncheck
 WORKDIR /src
-RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg govulncheck ./...
+RUN --mount=type=cache,target=/root/.cache/go-build,id=kres/root/.cache/go-build --mount=type=cache,target=/go/pkg,id=kres/go/pkg govulncheck ./...
 
 # runs unit-tests with race detector
 FROM base AS unit-tests-race
 WORKDIR /src
 ARG TESTPKGS
-RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg --mount=type=cache,target=/tmp CGO_ENABLED=1 go test -v -race -count 1 ${TESTPKGS}
+RUN --mount=type=cache,target=/root/.cache/go-build,id=kres/root/.cache/go-build --mount=type=cache,target=/go/pkg,id=kres/go/pkg --mount=type=cache,target=/tmp,id=kres/tmp CGO_ENABLED=1 go test -v -race -count 1 ${TESTPKGS}
 
 # runs unit-tests
 FROM base AS unit-tests-run
 WORKDIR /src
 ARG TESTPKGS
-RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg --mount=type=cache,target=/tmp go test -v -covermode=atomic -coverprofile=coverage.txt -coverpkg=${TESTPKGS} -count 1 ${TESTPKGS}
+RUN --mount=type=cache,target=/root/.cache/go-build,id=kres/root/.cache/go-build --mount=type=cache,target=/go/pkg,id=kres/go/pkg --mount=type=cache,target=/tmp,id=kres/tmp go test -v -covermode=atomic -coverprofile=coverage.txt -coverpkg=${TESTPKGS} -count 1 ${TESTPKGS}
 
 FROM embed-generate AS embed-abbrev-generate
 WORKDIR /src
@@ -116,7 +116,7 @@ ARG GO_LDFLAGS
 ARG VERSION_PKG="internal/version"
 ARG SHA
 ARG TAG
-RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg GOARCH=amd64 GOOS=darwin go build ${GO_BUILDFLAGS} -ldflags "${GO_LDFLAGS} -X ${VERSION_PKG}.Name=kres -X ${VERSION_PKG}.SHA=${SHA} -X ${VERSION_PKG}.Tag=${TAG}" -o /kres-darwin-amd64
+RUN --mount=type=cache,target=/root/.cache/go-build,id=kres/root/.cache/go-build --mount=type=cache,target=/go/pkg,id=kres/go/pkg GOARCH=amd64 GOOS=darwin go build ${GO_BUILDFLAGS} -ldflags "${GO_LDFLAGS} -X ${VERSION_PKG}.Name=kres -X ${VERSION_PKG}.SHA=${SHA} -X ${VERSION_PKG}.Tag=${TAG}" -o /kres-darwin-amd64
 
 # builds kres-darwin-arm64
 FROM base AS kres-darwin-arm64-build
@@ -128,7 +128,7 @@ ARG GO_LDFLAGS
 ARG VERSION_PKG="internal/version"
 ARG SHA
 ARG TAG
-RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg GOARCH=arm64 GOOS=darwin go build ${GO_BUILDFLAGS} -ldflags "${GO_LDFLAGS} -X ${VERSION_PKG}.Name=kres -X ${VERSION_PKG}.SHA=${SHA} -X ${VERSION_PKG}.Tag=${TAG}" -o /kres-darwin-arm64
+RUN --mount=type=cache,target=/root/.cache/go-build,id=kres/root/.cache/go-build --mount=type=cache,target=/go/pkg,id=kres/go/pkg GOARCH=arm64 GOOS=darwin go build ${GO_BUILDFLAGS} -ldflags "${GO_LDFLAGS} -X ${VERSION_PKG}.Name=kres -X ${VERSION_PKG}.SHA=${SHA} -X ${VERSION_PKG}.Tag=${TAG}" -o /kres-darwin-arm64
 
 # builds kres-linux-amd64
 FROM base AS kres-linux-amd64-build
@@ -140,7 +140,7 @@ ARG GO_LDFLAGS
 ARG VERSION_PKG="internal/version"
 ARG SHA
 ARG TAG
-RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg GOARCH=amd64 GOOS=linux go build ${GO_BUILDFLAGS} -ldflags "${GO_LDFLAGS} -X ${VERSION_PKG}.Name=kres -X ${VERSION_PKG}.SHA=${SHA} -X ${VERSION_PKG}.Tag=${TAG}" -o /kres-linux-amd64
+RUN --mount=type=cache,target=/root/.cache/go-build,id=kres/root/.cache/go-build --mount=type=cache,target=/go/pkg,id=kres/go/pkg GOARCH=amd64 GOOS=linux go build ${GO_BUILDFLAGS} -ldflags "${GO_LDFLAGS} -X ${VERSION_PKG}.Name=kres -X ${VERSION_PKG}.SHA=${SHA} -X ${VERSION_PKG}.Tag=${TAG}" -o /kres-linux-amd64
 
 # builds kres-linux-arm64
 FROM base AS kres-linux-arm64-build
@@ -152,7 +152,7 @@ ARG GO_LDFLAGS
 ARG VERSION_PKG="internal/version"
 ARG SHA
 ARG TAG
-RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg GOARCH=arm64 GOOS=linux go build ${GO_BUILDFLAGS} -ldflags "${GO_LDFLAGS} -X ${VERSION_PKG}.Name=kres -X ${VERSION_PKG}.SHA=${SHA} -X ${VERSION_PKG}.Tag=${TAG}" -o /kres-linux-arm64
+RUN --mount=type=cache,target=/root/.cache/go-build,id=kres/root/.cache/go-build --mount=type=cache,target=/go/pkg,id=kres/go/pkg GOARCH=arm64 GOOS=linux go build ${GO_BUILDFLAGS} -ldflags "${GO_LDFLAGS} -X ${VERSION_PKG}.Name=kres -X ${VERSION_PKG}.SHA=${SHA} -X ${VERSION_PKG}.Tag=${TAG}" -o /kres-linux-arm64
 
 FROM scratch AS kres-darwin-amd64
 COPY --from=kres-darwin-amd64-build /kres-darwin-amd64 /kres-darwin-amd64

--- a/internal/output/dockerfile/step/run.go
+++ b/internal/output/dockerfile/step/run.go
@@ -54,9 +54,23 @@ func (step *RunStep) Env(name, value string) *RunStep {
 	return step
 }
 
+// CacheOption is a function that modifies cache mount.
+type CacheOption func(*string)
+
+// CacheLocked modifies cache mount to be locked.
+func CacheLocked(mount *string) {
+	*mount += ",sharing=locked"
+}
+
 // MountCache mounts cache at specified target path.
-func (step *RunStep) MountCache(target string) *RunStep {
-	step.mounts = append(step.mounts, "type=cache,target="+target)
+func (step *RunStep) MountCache(target, idPrefix string, opts ...CacheOption) *RunStep {
+	mount := "type=cache,target=" + target + ",id=" + idPrefix + target
+
+	for _, opt := range opts {
+		opt(&mount)
+	}
+
+	step.mounts = append(step.mounts, mount)
 
 	return step
 }

--- a/internal/output/dockerfile/step/step_test.go
+++ b/internal/output/dockerfile/step/step_test.go
@@ -48,16 +48,20 @@ func TestGenerate(t *testing.T) {
 			"RUN --security=insecure CGOENABLED=0 BUILD=1 go build ./...\n",
 		},
 		{
-			step.Run("go", "build", "./...").MountCache("/root/go/.cache"),
-			"RUN --mount=type=cache,target=/root/go/.cache go build ./...\n",
+			step.Run("go", "build", "./...").MountCache("/root/go/.cache", "prj"),
+			"RUN --mount=type=cache,target=/root/go/.cache,id=prj/root/go/.cache go build ./...\n",
 		},
 		{
-			step.Run("go", "build", "./...").MountCache("/root/go/.cache"),
-			"RUN --mount=type=cache,target=/root/go/.cache go build ./...\n",
+			step.Run("go", "build", "./...").MountCache("/root/go/.cache", "prj"),
+			"RUN --mount=type=cache,target=/root/go/.cache,id=prj/root/go/.cache go build ./...\n",
 		},
 		{
-			step.Script("curl http://example.com/ | tar xzf -").MountCache("/root/go/.cache"),
-			"RUN --mount=type=cache,target=/root/go/.cache curl http://example.com/ | tar xzf -\n",
+			step.Run("go", "build", "./...").MountCache("/root/go/.cache", "prj", step.CacheLocked),
+			"RUN --mount=type=cache,target=/root/go/.cache,id=prj/root/go/.cache,sharing=locked go build ./...\n",
+		},
+		{
+			step.Script("curl http://example.com/ | tar xzf -").MountCache("/root/go/.cache", "prj"),
+			"RUN --mount=type=cache,target=/root/go/.cache,id=prj/root/go/.cache curl http://example.com/ | tar xzf -\n",
 		},
 		{
 			step.Arg("GOFUMPT_VERSION"),

--- a/internal/project/custom/custom.go
+++ b/internal/project/custom/custom.go
@@ -154,7 +154,7 @@ func (step *Step) CompileDockerfile(output *dockerfile.Output) error {
 			case stageStep.Script != nil:
 				script := dockerstep.Script(stageStep.Script.Command)
 				for _, cache := range stageStep.Script.Cache {
-					script.MountCache(cache)
+					script.MountCache(cache, step.meta.GitHubRepository)
 				}
 
 				s.Step(script)

--- a/internal/project/golang/build.go
+++ b/internal/project/golang/build.go
@@ -99,8 +99,8 @@ func (build *Build) CompileDockerfile(output *dockerfile.Output) error {
 		}
 
 		script := step.Script(fmt.Sprintf(`go build%s -ldflags "%s" -o /%s`, buildFlags, ldflags, name)).
-			MountCache(filepath.Join(build.meta.CachePath, "go-build")).
-			MountCache(filepath.Join(build.meta.GoPath, "pkg"))
+			MountCache(filepath.Join(build.meta.CachePath, "go-build"), build.meta.GitHubRepository).
+			MountCache(filepath.Join(build.meta.GoPath, "pkg"), build.meta.GitHubRepository)
 
 		if opts != nil {
 			opts.set(script)

--- a/internal/project/golang/deepcopy.go
+++ b/internal/project/golang/deepcopy.go
@@ -53,8 +53,8 @@ func (deepcopy *DeepCopy) ToolchainBuild(stage *dockerfile.Stage) error {
 		Step(step.Script(fmt.Sprintf(
 			`go install github.com/siderolabs/deep-copy@${DEEPCOPY_VERSION} \
 	&& mv /go/bin/deep-copy %s/deep-copy`, deepcopy.meta.BinPath)).
-			MountCache(filepath.Join(deepcopy.meta.CachePath, "go-build")).
-			MountCache(filepath.Join(deepcopy.meta.GoPath, "pkg")),
+			MountCache(filepath.Join(deepcopy.meta.CachePath, "go-build"), deepcopy.meta.GitHubRepository).
+			MountCache(filepath.Join(deepcopy.meta.GoPath, "pkg"), deepcopy.meta.GitHubRepository),
 		)
 
 	return nil

--- a/internal/project/golang/generate.go
+++ b/internal/project/golang/generate.go
@@ -131,8 +131,8 @@ func (generate *Generate) ToolchainBuild(stage *dockerfile.Stage) error {
 	stage.
 		Step(step.Arg("GOIMPORTS_VERSION")).
 		Step(step.Script("go install golang.org/x/tools/cmd/goimports@v${GOIMPORTS_VERSION}").
-			MountCache(filepath.Join(generate.meta.CachePath, "go-build")).
-			MountCache(filepath.Join(generate.meta.GoPath, "pkg")),
+			MountCache(filepath.Join(generate.meta.CachePath, "go-build"), generate.meta.GitHubRepository).
+			MountCache(filepath.Join(generate.meta.GoPath, "pkg"), generate.meta.GitHubRepository),
 		).
 		Step(step.Run("mv", filepath.Join(generate.meta.GoPath, "bin", "goimports"), generate.meta.BinPath))
 
@@ -144,20 +144,20 @@ func (generate *Generate) ToolchainBuild(stage *dockerfile.Stage) error {
 	stage.
 		Step(step.Arg("PROTOBUF_GO_VERSION")).
 		Step(step.Script("go install google.golang.org/protobuf/cmd/protoc-gen-go@v${PROTOBUF_GO_VERSION}").
-			MountCache(filepath.Join(generate.meta.CachePath, "go-build")).
-			MountCache(filepath.Join(generate.meta.GoPath, "pkg")),
+			MountCache(filepath.Join(generate.meta.CachePath, "go-build"), generate.meta.GitHubRepository).
+			MountCache(filepath.Join(generate.meta.GoPath, "pkg"), generate.meta.GitHubRepository),
 		).
 		Step(step.Run("mv", filepath.Join(generate.meta.GoPath, "bin", "protoc-gen-go"), generate.meta.BinPath)).
 		Step(step.Arg("GRPC_GO_VERSION")).
 		Step(step.Script("go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v${GRPC_GO_VERSION}").
-			MountCache(filepath.Join(generate.meta.CachePath, "go-build")).
-			MountCache(filepath.Join(generate.meta.GoPath, "pkg")),
+			MountCache(filepath.Join(generate.meta.CachePath, "go-build"), generate.meta.GitHubRepository).
+			MountCache(filepath.Join(generate.meta.GoPath, "pkg"), generate.meta.GitHubRepository),
 		).
 		Step(step.Run("mv", filepath.Join(generate.meta.GoPath, "bin", "protoc-gen-go-grpc"), generate.meta.BinPath)).
 		Step(step.Arg("GRPC_GATEWAY_VERSION")).
 		Step(step.Script("go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway@v${GRPC_GATEWAY_VERSION}").
-			MountCache(filepath.Join(generate.meta.CachePath, "go-build")).
-			MountCache(filepath.Join(generate.meta.GoPath, "pkg")),
+			MountCache(filepath.Join(generate.meta.CachePath, "go-build"), generate.meta.GitHubRepository).
+			MountCache(filepath.Join(generate.meta.GoPath, "pkg"), generate.meta.GitHubRepository),
 		).
 		Step(step.Run("mv", filepath.Join(generate.meta.GoPath, "bin", "protoc-gen-grpc-gateway"), generate.meta.BinPath))
 
@@ -165,8 +165,8 @@ func (generate *Generate) ToolchainBuild(stage *dockerfile.Stage) error {
 		stage.
 			Step(step.Arg("VTPROTOBUF_VERSION")).
 			Step(step.Script("go install github.com/planetscale/vtprotobuf/cmd/protoc-gen-go-vtproto@v${VTPROTOBUF_VERSION}").
-				MountCache(filepath.Join(generate.meta.CachePath, "go-build")).
-				MountCache(filepath.Join(generate.meta.GoPath, "pkg")),
+				MountCache(filepath.Join(generate.meta.CachePath, "go-build"), generate.meta.GitHubRepository).
+				MountCache(filepath.Join(generate.meta.GoPath, "pkg"), generate.meta.GitHubRepository),
 			).
 			Step(step.Run("mv", filepath.Join(generate.meta.GoPath, "bin", "protoc-gen-go-vtproto"), generate.meta.BinPath))
 	}
@@ -335,8 +335,8 @@ func (generate *Generate) CompileDockerfile(output *dockerfile.Output) error {
 			Step(step.WorkDir("/src")).
 			Step(step.Copy(license.Header, filepath.Join("./hack/", license.Header))).
 			Step(step.Script(fmt.Sprintf("go generate %s/...", spec.Source)).
-				MountCache(filepath.Join(generate.meta.CachePath, "go-build")).
-				MountCache(filepath.Join(generate.meta.GoPath, "pkg")),
+				MountCache(filepath.Join(generate.meta.CachePath, "go-build"), generate.meta.GitHubRepository).
+				MountCache(filepath.Join(generate.meta.GoPath, "pkg"), generate.meta.GitHubRepository),
 			).
 			Step(step.Run(
 				"goimports",

--- a/internal/project/golang/golangcilint.go
+++ b/internal/project/golang/golangcilint.go
@@ -72,9 +72,9 @@ func (lint *GolangciLint) CompileDockerfile(output *dockerfile.Output) error {
 		Step(step.Env("GOGC", "50")).
 		Step(step.Run("golangci-lint", "config", "verify", "--config", ".golangci.yml")).
 		Step(step.Run("golangci-lint", "run", "--config", ".golangci.yml").
-			MountCache(filepath.Join(lint.meta.CachePath, "go-build")).
-			MountCache(filepath.Join(lint.meta.CachePath, "golangci-lint")).
-			MountCache(filepath.Join(lint.meta.GoPath, "pkg")),
+			MountCache(filepath.Join(lint.meta.CachePath, "go-build"), lint.meta.GitHubRepository).
+			MountCache(filepath.Join(lint.meta.CachePath, "golangci-lint"), lint.meta.GitHubRepository, step.CacheLocked).
+			MountCache(filepath.Join(lint.meta.GoPath, "pkg"), lint.meta.GitHubRepository),
 		)
 
 	return nil

--- a/internal/project/golang/govulncheck.go
+++ b/internal/project/golang/govulncheck.go
@@ -61,8 +61,9 @@ func (lint *GoVulnCheck) CompileDockerfile(output *dockerfile.Output) error {
 		Step(step.Script(
 			`govulncheck ./...`,
 		).
-			MountCache(filepath.Join(lint.meta.CachePath, "go-build")).
-			MountCache(filepath.Join(lint.meta.GoPath, "pkg")))
+			MountCache(filepath.Join(lint.meta.CachePath, "go-build"), lint.meta.GitHubRepository).
+			MountCache(filepath.Join(lint.meta.GoPath, "pkg"), lint.meta.GitHubRepository),
+		)
 
 	return nil
 }

--- a/internal/project/golang/linters.go
+++ b/internal/project/golang/linters.go
@@ -44,14 +44,14 @@ func (linters *Linters) ToolchainBuild(stage *dockerfile.Stage) error {
 				"go install github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCILINT_VERSION} \\\n"+
 					"\t&& mv /go/bin/golangci-lint %s/golangci-lint", linters.meta.BinPath),
 		).
-			MountCache(filepath.Join(linters.meta.CachePath, "go-build")).
-			MountCache(filepath.Join(linters.meta.GoPath, "pkg")),
+			MountCache(filepath.Join(linters.meta.CachePath, "go-build"), linters.meta.GitHubRepository).
+			MountCache(filepath.Join(linters.meta.GoPath, "pkg"), linters.meta.GitHubRepository),
 		).
 		Step(step.Script(fmt.Sprintf(
 			`go install golang.org/x/vuln/cmd/govulncheck@latest \
 	&& mv /go/bin/govulncheck %s/govulncheck`, linters.meta.BinPath)).
-			MountCache(filepath.Join(linters.meta.CachePath, "go-build")).
-			MountCache(filepath.Join(linters.meta.GoPath, "pkg")),
+			MountCache(filepath.Join(linters.meta.CachePath, "go-build"), linters.meta.GitHubRepository).
+			MountCache(filepath.Join(linters.meta.GoPath, "pkg"), linters.meta.GitHubRepository),
 		).
 		Step(step.Arg("GOFUMPT_VERSION")).
 		Step(step.Script(fmt.Sprintf(

--- a/internal/project/golang/toolchain.go
+++ b/internal/project/golang/toolchain.go
@@ -258,8 +258,8 @@ func (toolchain *Toolchain) CompileDockerfile(output *dockerfile.Output) error {
 
 	for _, rootDir := range toolchain.meta.GoRootDirectories {
 		base.Step(step.Run("cd", rootDir)).
-			Step(step.Run("go", "mod", "download").MountCache(filepath.Join(toolchain.meta.GoPath, "pkg"))).
-			Step(step.Run("go", "mod", "verify").MountCache(filepath.Join(toolchain.meta.GoPath, "pkg")))
+			Step(step.Run("go", "mod", "download").MountCache(filepath.Join(toolchain.meta.GoPath, "pkg"), toolchain.meta.GitHubRepository)).
+			Step(step.Run("go", "mod", "verify").MountCache(filepath.Join(toolchain.meta.GoPath, "pkg"), toolchain.meta.GitHubRepository))
 	}
 
 	for _, directory := range toolchain.meta.GoDirectories {
@@ -278,7 +278,7 @@ func (toolchain *Toolchain) CompileDockerfile(output *dockerfile.Output) error {
 		}
 	}
 
-	base.Step(step.Script(`go list -mod=readonly all >/dev/null`).MountCache(filepath.Join(toolchain.meta.GoPath, "pkg")))
+	base.Step(step.Script(`go list -mod=readonly all >/dev/null`).MountCache(filepath.Join(toolchain.meta.GoPath, "pkg"), toolchain.meta.GitHubRepository))
 
 	return nil
 }

--- a/internal/project/golang/unit_tests.go
+++ b/internal/project/golang/unit_tests.go
@@ -97,9 +97,9 @@ func (tests *UnitTests) CompileDockerfile(output *dockerfile.Output) error {
 					`go test -v -covermode=atomic -coverprofile=coverage.txt -coverpkg=${TESTPKGS} -count 1 %s${TESTPKGS}`,
 					extraArgs),
 			).
-				MountCache(filepath.Join(tests.meta.CachePath, "go-build")).
-				MountCache(filepath.Join(tests.meta.GoPath, "pkg")).
-				MountCache("/tmp")))
+				MountCache(filepath.Join(tests.meta.CachePath, "go-build"), tests.meta.GitHubRepository).
+				MountCache(filepath.Join(tests.meta.GoPath, "pkg"), tests.meta.GitHubRepository).
+				MountCache("/tmp", tests.meta.GitHubRepository)))
 
 	output.Stage(tests.Name()).
 		From("scratch").
@@ -133,9 +133,9 @@ func (tests *UnitTests) CompileDockerfile(output *dockerfile.Output) error {
 					extraArgs,
 				),
 			).
-				MountCache(filepath.Join(tests.meta.CachePath, "go-build")).
-				MountCache(filepath.Join(tests.meta.GoPath, "pkg")).
-				MountCache("/tmp").
+				MountCache(filepath.Join(tests.meta.CachePath, "go-build"), tests.meta.GitHubRepository).
+				MountCache(filepath.Join(tests.meta.GoPath, "pkg"), tests.meta.GitHubRepository).
+				MountCache("/tmp", tests.meta.GitHubRepository).
 				Env("CGO_ENABLED", "1")))
 
 	return nil

--- a/internal/project/js/build.go
+++ b/internal/project/js/build.go
@@ -93,8 +93,8 @@ func (build *Build) CompileDockerfile(output *dockerfile.Output) error {
 		Description("builds " + build.Name()).
 		From("--platform=${BUILDPLATFORM} js").
 		Step(step.Arg(buildArgsVarName)).
-		Step(step.Script("bun run build ${" + buildArgsVarName + "}").
-			MountCache(build.meta.JSCachePath)).
+		Step(step.Script("bun run build ${"+buildArgsVarName+"}").
+			MountCache(build.meta.JSCachePath, build.meta.GitHubRepository)).
 		Step(step.Script("mkdir -p " + outputDir)).
 		Step(step.Script("cp -rf ./dist/* " + outputDir))
 

--- a/internal/project/js/eslint.go
+++ b/internal/project/js/eslint.go
@@ -44,7 +44,7 @@ func (lint *EsLint) CompileDockerfile(output *dockerfile.Output) error {
 		Description("runs eslint").
 		From("js").
 		Step(step.Script("bun run lint").
-			MountCache(lint.meta.JSCachePath))
+			MountCache(lint.meta.JSCachePath, lint.meta.GitHubRepository))
 
 	return nil
 }

--- a/internal/project/js/protobuf.go
+++ b/internal/project/js/protobuf.go
@@ -90,8 +90,8 @@ func (proto *Protobuf) ToolchainBuild(stage *dockerfile.Stage) error {
 	stage.
 		Step(step.Arg("PROTOBUF_GRPC_GATEWAY_TS_VERSION")).
 		Step(step.Script("go install github.com/siderolabs/protoc-gen-grpc-gateway-ts@v${PROTOBUF_GRPC_GATEWAY_TS_VERSION}").
-			MountCache(filepath.Join(proto.meta.CachePath, "go-build")).
-			MountCache(filepath.Join(proto.meta.GoPath, "pkg")),
+			MountCache(filepath.Join(proto.meta.CachePath, "go-build"), proto.meta.GitHubRepository).
+			MountCache(filepath.Join(proto.meta.GoPath, "pkg"), proto.meta.GitHubRepository),
 		).
 		Step(step.Run("mv", filepath.Join(proto.meta.GoPath, "bin", "protoc-gen-grpc-gateway-ts"), proto.meta.BinPath))
 

--- a/internal/project/js/toolchain.go
+++ b/internal/project/js/toolchain.go
@@ -135,7 +135,7 @@ func (toolchain *Toolchain) CompileDockerfile(output *dockerfile.Output) error {
 
 	base.Step(step.Copy(filepath.Join(toolchain.sourceDir, "package.json"), "./")).
 		Step(step.Script("bun install").
-			MountCache(toolchain.meta.JSCachePath)).
+			MountCache(toolchain.meta.JSCachePath, toolchain.meta.GitHubRepository, step.CacheLocked)).
 		Step(step.Copy(filepath.Join(toolchain.sourceDir, "tsconfig*.json"), "./")).
 		Step(step.Copy(filepath.Join(toolchain.sourceDir, "bunfig.toml"), "./")).
 		Step(step.Copy(filepath.Join(toolchain.sourceDir, "*.html"), "./")).

--- a/internal/project/js/unit_tests.go
+++ b/internal/project/js/unit_tests.go
@@ -35,9 +35,9 @@ func (tests *UnitTests) CompileDockerfile(output *dockerfile.Output) error {
 		Description("runs js unit-tests").
 		From("js").
 		Step(step.Script(`bun add -d @happy-dom/global-registrator`).
-			MountCache(tests.meta.JSCachePath)).
+			MountCache(tests.meta.JSCachePath, tests.meta.GitHubRepository, step.CacheLocked)).
 		Step(step.Script(`bun run test`).
-			MountCache(tests.meta.JSCachePath).
+			MountCache(tests.meta.JSCachePath, tests.meta.GitHubRepository).
 			Env("CI", "true"))
 
 	return nil


### PR DESCRIPTION
Otherwise by default cache ID is just `target` path, so all caches from all projects go into the same object.

Also lock the linter cache, as I don't think it supports concurrent writes.

See https://docs.docker.com/reference/dockerfile/#run---mounttypecache