### PR TITLE
chore: remove golangci-lint config verify

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-03-10T15:41:49Z by kres 8946258.
+# Generated on 2025-03-24T12:23:13Z by kres 24cab8a.
 
 ARG TOOLCHAIN
 
@@ -73,7 +73,6 @@ FROM base AS lint-golangci-lint
 WORKDIR /src
 COPY .golangci.yml .
 ENV GOGC=50
-RUN golangci-lint config verify --config .golangci.yml
 RUN --mount=type=cache,target=/root/.cache/go-build,id=kres/root/.cache/go-build --mount=type=cache,target=/root/.cache/golangci-lint,id=kres/root/.cache/golangci-lint,sharing=locked --mount=type=cache,target=/go/pkg,id=kres/go/pkg golangci-lint run --config .golangci.yml
 
 # runs govulncheck

--- a/internal/project/golang/golangcilint.go
+++ b/internal/project/golang/golangcilint.go
@@ -70,7 +70,6 @@ func (lint *GolangciLint) CompileDockerfile(output *dockerfile.Output) error {
 		Step(step.WorkDir(filepath.Join("/src", lint.projectPath))).
 		Step(step.Copy(filepath.Join(lint.projectPath, ".golangci.yml"), ".")).
 		Step(step.Env("GOGC", "50")).
-		Step(step.Run("golangci-lint", "config", "verify", "--config", ".golangci.yml")).
 		Step(step.Run("golangci-lint", "run", "--config", ".golangci.yml").
 			MountCache(filepath.Join(lint.meta.CachePath, "go-build"), lint.meta.GitHubRepository).
 			MountCache(filepath.Join(lint.meta.CachePath, "golangci-lint"), lint.meta.GitHubRepository, step.CacheLocked).


### PR DESCRIPTION
They use upstream version of json validation, and currently are issuing breaking V2 release

https://github.com/golangci/golangci-lint/commit/f1f8343d12ac33720efeb5898141d1e065789751

We will add it back, once we complete our migration to v2.