### PR TITLE
fix: skip adding custom steps to make all target

### DIFF
--- a/internal/project/custom/custom.go
+++ b/internal/project/custom/custom.go
@@ -541,3 +541,6 @@ func (step *Step) CompileMakefile(output *makefile.Output) error {
 
 	return nil
 }
+
+// SkipAsMakefileDependency marks step as skipped in Makefile dependency graph.
+func (step *Step) SkipAsMakefileDependency() {}


### PR DESCRIPTION
Skip adding custom steps to make `all` target.