### PR TITLE
fix: disable `nolintlint` linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-04-14T12:32:42Z by kres d903dae-dirty.
+# Generated on 2025-05-05T10:34:00Z by kres be6d3a6a.
 
 version: "2"
 
@@ -48,6 +48,7 @@ linters:
     - protogetter # complains about us using Value field on typed spec, instead of GetValue which has a different signature
     - perfsprint # complains about us using fmt.Sprintf in non-performance critical code, updating just kres took too long
     - musttag # seems to be broken - goes into imported libraries and reports issues there
+    - nolintlint # gives false positives - disable until https://github.com/golangci/golangci-lint/issues/3228 is resolved
   # all available settings of specific linters
   settings:
     cyclop:
@@ -89,11 +90,6 @@ linters:
       simple: true
       range-loops: true # Report preallocation suggestions on range loops, true by default
       for-loops: false # Report preallocation suggestions on for loops, false by default
-    nolintlint:
-      allow-unused: false
-      allow-no-explanation: [ ]
-      require-explanation: false
-      require-specific: true
     rowserrcheck: { }
     testpackage: { }
     unparam:

--- a/internal/output/golangci/golangci.yml
+++ b/internal/output/golangci/golangci.yml
@@ -44,6 +44,7 @@ linters:
     - protogetter # complains about us using Value field on typed spec, instead of GetValue which has a different signature
     - perfsprint # complains about us using fmt.Sprintf in non-performance critical code, updating just kres took too long
     - musttag # seems to be broken - goes into imported libraries and reports issues there
+    - nolintlint # gives false positives - disable until https://github.com/golangci/golangci-lint/issues/3228 is resolved
   # all available settings of specific linters
   settings:
     cyclop:
@@ -85,11 +86,6 @@ linters:
       simple: true
       range-loops: true # Report preallocation suggestions on range loops, true by default
       for-loops: false # Report preallocation suggestions on for loops, false by default
-    nolintlint:
-      allow-unused: false
-      allow-no-explanation: [ ]
-      require-explanation: false
-      require-specific: true
     rowserrcheck: { }
     testpackage: { }
     unparam:


### PR DESCRIPTION
It gives false positives, failing CI runs - see https://github.com/golangci/golangci-lint/issues/3228#issuecomment-2796615846.