### PR TITLE
feat: sign with cosign checksums for release

### DIFF
--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -25,9 +25,9 @@ const (
 	// CodeCovActionVersion is the version of codecov github action.
 	// renovate: datasource=github-releases extractVersion=^(?<version>v\d+)\.\d+\.\d+$ depName=codecov/codecov-action
 	CodeCovActionVersion = "v5"
-	// CosignInstallActionVerson is the version of cosign install github action.
+	// CosignInstallerActionVersion is the version of release cosign-installer.
 	// renovate: datasource=github-releases extractVersion=^(?<version>v\d+)\.\d+\.\d+$ depName=sigstore/cosign-installer
-	CosignInstallActionVerson = "v3"
+	CosignInstallerActionVersion = "v3.8.2"
 	// DeepCopyVersion is the version of deepcopy.
 	// renovate: datasource=go depName=github.com/siderolabs/deep-copy
 	DeepCopyVersion = "v0.5.6"

--- a/internal/project/common/gh_workflow.go
+++ b/internal/project/common/gh_workflow.go
@@ -282,17 +282,25 @@ func (gh *GHWorkflow) CompileGitHubWorkflow(o *ghworkflow.Output) error {
 					SetWith("files", strings.Join(artifacts, "\n"))
 
 				if step.ReleaseStep.GenerateChecksums {
+					jobDef.Permissions["id-token"] = "write"
+
+					cosignStep := ghworkflow.Step("Install Cosign").
+						SetUses("sigstore/cosign-installer@" + config.CosignInstallerActionVersion)
+					jobDef.Steps = append(jobDef.Steps, cosignStep)
+
 					checkSumCommands := []string{
 						fmt.Sprintf("cd %s", step.ReleaseStep.BaseDirectory),
 						fmt.Sprintf("sha256sum %s > %s", strings.Join(step.ReleaseStep.Artifacts, " "), "sha256sum.txt"),
 						fmt.Sprintf("sha512sum %s > %s", strings.Join(step.ReleaseStep.Artifacts, " "), "sha512sum.txt"),
+						fmt.Sprintf("cosign sign-blob --output sha256sum.txt.sig --yes sha256sum.txt"),
+						fmt.Sprintf("cosign sign-blob --output sha512sum.txt.sig --yes sha512sum.txt"),
 					}
 
 					checkSumStep := ghworkflow.Step("Generate Checksums").
 						SetCommand(strings.Join(checkSumCommands, "\n"))
 
 					releaseStep.
-						SetWith("files", strings.Join(artifacts, "\n")+"\n"+filepath.Join(step.ReleaseStep.BaseDirectory, "sha*.txt"))
+						SetWith("files", strings.Join(artifacts, "\n")+"\n"+filepath.Join(step.ReleaseStep.BaseDirectory, "sha*.txt*"))
 
 					jobDef.Steps = append(jobDef.Steps, checkSumStep)
 				}


### PR DESCRIPTION
produce signatures for verifying checksums to allow verifying against tampering.

fixes: #519 