### PR TITLE
feat: add support for stale/lock workflows

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,0 +1,21 @@
+# THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
+#
+# Generated on 2025-06-05T12:39:56Z by kres fc6afbe-dirty.
+
+name: Lock old issues
+"on":
+  schedule:
+    - cron: 0 2 * * *
+permissions:
+  issues: write
+jobs:
+  action:
+    runs-on:
+      - ubuntu-latest
+    steps:
+      - name: Lock old issues
+        uses: dessant/lock-threads@v5
+        with:
+          issue-inactive-days: "60"
+          log-output: "true"
+          process-only: issues

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,27 @@
+# THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
+#
+# Generated on 2025-06-05T12:39:56Z by kres fc6afbe-dirty.
+
+name: Close stale issues and PRs
+"on":
+  schedule:
+    - cron: 30 1 * * *
+permissions:
+  issues: write
+  pull-requests: write
+jobs:
+  stale:
+    runs-on:
+      - ubuntu-latest
+    steps:
+      - name: Close stale issues and PRs
+        uses: actions/stale@v9.1.0
+        with:
+          close-issue-message: This issue was closed because it has been stalled for 7 days with no activity.
+          days-before-issue-close: "5"
+          days-before-issue-stale: "180"
+          days-before-pr-close: "-1"
+          days-before-pr-stale: "45"
+          operations-per-run: "2000"
+          stale-issue-message: This issue is stale because it has been open 180 days with no activity. Remove stale label or comment or this will be closed in 7 days.
+          stale-pr-message: This PR is stale because it has been open 45 days with no activity.

--- a/cmd/kres/cmd/gen.go
+++ b/cmd/kres/cmd/gen.go
@@ -99,7 +99,7 @@ func runGen() error {
 	case "drone":
 		outputs = append(outputs, output.Wrap[drone.Compiler](drone.NewOutput()))
 	case "ghaction":
-		outputs = append(outputs, output.Wrap[ghworkflow.Compiler](ghworkflow.NewOutput(options.MainBranch, !options.CompileGithubWorkflowsOnly)))
+		outputs = append(outputs, output.Wrap[ghworkflow.Compiler](ghworkflow.NewOutput(options.MainBranch, !options.CompileGithubWorkflowsOnly, !options.SkipStaleWorkflow)))
 	}
 
 	if err := proj.Compile(outputs); err != nil {

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -112,4 +112,10 @@ const (
 	// VTProtobufVersion is the version of vtprotobuf.
 	// renovate: datasource=go depName=github.com/planetscale/vtprotobuf
 	VTProtobufVersion = "v0.6.0"
+	// StaleActionVersion is the version of stale github action.
+	// renovate: datasource=github-releases depName=actions/stale
+	StaleActionVersion = "v9.1.0"
+	// LockThreadsActionVersion is the version of lock threads github action.
+	// renovate: datasource=github-releases depName=dessant/lock-threads
+	LockThreadsActionVersion = "v5.0.1"
 )

--- a/internal/output/ghworkflow/gh_workflow.go
+++ b/internal/output/ghworkflow/gh_workflow.go
@@ -86,7 +86,7 @@ type Output struct {
 }
 
 // NewOutput creates new .github/workflows/ci.yaml output.
-func NewOutput(mainBranch string, withDefaultJob bool) *Output {
+func NewOutput(mainBranch string, withDefaultJob bool, withStaleJob bool) *Output {
 	workflows := map[string]*Workflow{
 		ciWorkflow: {
 			Name: "default",
@@ -141,6 +141,74 @@ func NewOutput(mainBranch string, withDefaultJob bool) *Output {
 				},
 			},
 		},
+	}
+
+	if withStaleJob {
+		workflows[".github/workflows/lock.yml"] = &Workflow{
+			Name: "Lock old issues",
+			On: On{
+				Schedule: []Schedule{
+					{
+						Cron: "0 2 * * *", // Every day at 2 AM
+					},
+				},
+			},
+			Permissions: map[string]string{
+				"issues": "write",
+			},
+			Jobs: map[string]*Job{
+				"action": {
+					RunsOn: []string{"ubuntu-latest"},
+					Steps: []*JobStep{
+						{
+							Name: "Lock old issues",
+							Uses: "dessant/lock-threads@v5",
+							With: map[string]string{
+								"issue-inactive-days": "60",
+								"process-only":        "issues",
+								"log-output":          "true",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		workflows[".github/workflows/stale.yml"] = &Workflow{
+			Name: "Close stale issues and PRs",
+			On: On{
+				Schedule: []Schedule{
+					{
+						Cron: "30 1 * * *", // Every day at 1:30 AM
+					},
+				},
+			},
+			Permissions: map[string]string{
+				"issues":        "write",
+				"pull-requests": "write",
+			},
+			Jobs: map[string]*Job{
+				"stale": {
+					RunsOn: []string{"ubuntu-latest"},
+					Steps: []*JobStep{
+						{
+							Name: "Close stale issues and PRs",
+							Uses: "actions/stale@" + config.StaleActionVersion,
+							With: map[string]string{
+								"stale-issue-message":     "This issue is stale because it has been open 180 days with no activity. Remove stale label or comment or this will be closed in 7 days.",
+								"stale-pr-message":        "This PR is stale because it has been open 45 days with no activity.",
+								"close-issue-message":     "This issue was closed because it has been stalled for 7 days with no activity.",
+								"days-before-issue-stale": "180",
+								"days-before-pr-stale":    "45",
+								"days-before-issue-close": "5",
+								"days-before-pr-close":    "-1",   // never close PRs
+								"operations-per-run":      "2000", // the maximum number of operations to perform per run
+							},
+						},
+					},
+				},
+			},
+		}
 	}
 
 	if withDefaultJob {

--- a/internal/output/ghworkflow/types.go
+++ b/internal/output/ghworkflow/types.go
@@ -11,6 +11,7 @@ type Workflow struct {
 	Name        string `yaml:"name"`
 	Concurrency `yaml:"concurrency,omitempty"`
 	On          `yaml:"on"`
+	Permissions map[string]string `yaml:"permissions,omitempty"`
 	Env         map[string]string `yaml:"env,omitempty"`
 	Jobs        map[string]*Job   `yaml:"jobs"`
 }

--- a/internal/project/common/repository.go
+++ b/internal/project/common/repository.go
@@ -47,6 +47,8 @@ type Repository struct { //nolint:govet
 	LicenseChecks []licensepolicy.Spec `yaml:"licenseChecks"`
 
 	BotName string `yaml:"botName"`
+
+	SkipStaleWorkflow bool `yaml:"skipStaleWorkflow"`
 }
 
 // LicenseConfig configures the license.
@@ -100,6 +102,7 @@ func NewRepository(meta *meta.Options) *Repository {
 // AfterLoad maps back main branch override to meta.
 func (r *Repository) AfterLoad() error {
 	r.meta.MainBranch = r.MainBranch
+	r.meta.SkipStaleWorkflow = r.SkipStaleWorkflow
 
 	return nil
 }

--- a/internal/project/meta/meta.go
+++ b/internal/project/meta/meta.go
@@ -93,6 +93,9 @@ type Options struct { //nolint:govet
 
 	// HelmChartDir is the path to helm chart directory.
 	HelmChartDir string
+
+	// SkipStaleWorkflow indicates that stale workflow should not be generated.
+	SkipStaleWorkflow bool
 }
 
 // Command defines Golang executable build configuration.


### PR DESCRIPTION
Borrow the configuration/flow from Talos repo, where these flows run for a long time and pretty successfully manage stale issues/discussions/PRs.

To disable it, use the following in `.kres.yaml`:

```yaml
kind: common.Repository
spec:
  skipStaleWorkflow: true
```