### PR TITLE
feat: support custom image names in the integration tests targets

### DIFF
--- a/internal/project/auto/config.go
+++ b/internal/project/auto/config.go
@@ -48,7 +48,7 @@ type Helm struct {
 
 // IntegrationTests defines integration tests builder to be generated.
 type IntegrationTests struct {
-	Tests []IntegrationTestConfig
+	Tests []IntegrationTestConfig `yaml:"tests"`
 }
 
 // IntegrationTestConfig defines the integration tests build configuration.
@@ -56,5 +56,6 @@ type IntegrationTestConfig struct {
 	Outputs           map[string]map[string]string `yaml:"outputs"`
 	Name              string                       `yaml:"name"`
 	Path              string                       `yaml:"path"`
+	ImageName         string                       `yaml:"imageName"`
 	EnableDockerImage bool                         `yaml:"enableDockerImage"`
 }

--- a/internal/project/auto/integration_tests.go
+++ b/internal/project/auto/integration_tests.go
@@ -42,8 +42,14 @@ func (builder *builder) BuildIntegrationTests() error {
 		builder.targets = append(builder.targets, build)
 
 		if spec.EnableDockerImage {
+			imageName := spec.Name
+
+			if spec.ImageName != "" {
+				imageName = spec.ImageName
+			}
+
 			image := common.NewImage(
-				builder.meta, spec.Name,
+				builder.meta, imageName,
 			)
 
 			image.AddInput(build)


### PR DESCRIPTION
By default it still falls back to the same name as the integration test step.