### PR TITLE
feat: generate coverage for the integration tests

### DIFF
--- a/internal/project/auto/config.go
+++ b/internal/project/auto/config.go
@@ -28,9 +28,10 @@ type CustomSteps struct {
 
 // CustomStep defines a custom step to be built.
 type CustomStep struct {
-	Name     string   `yaml:"name"`
-	Inputs   []string `yaml:"inputs"`
-	Toplevel bool     `yaml:"toplevel"`
+	Name       string   `yaml:"name"`
+	Inputs     []string `yaml:"inputs"`
+	Dependants []string `yaml:"dependants"`
+	Toplevel   bool     `yaml:"toplevel"`
 }
 
 // CI defines CI settings.

--- a/internal/project/auto/custom.go
+++ b/internal/project/auto/custom.go
@@ -49,6 +49,16 @@ func (builder *builder) BuildCustom() error {
 			step.AddInput(input)
 		}
 
+		for _, dependantName := range spec.Dependants {
+			dependant := dag.FindByName(dependantName, append(builder.targets, createdSteps...)...)
+
+			if dependant == nil {
+				return fmt.Errorf("failed to find dependant node %q for custom step %q", dependantName, spec.Name)
+			}
+
+			dependant.AddInput(step)
+		}
+
 		createdSteps = append(createdSteps, step)
 	}
 

--- a/internal/project/auto/golang.go
+++ b/internal/project/auto/golang.go
@@ -262,7 +262,7 @@ func (builder *builder) BuildGolang() error {
 		builder.targets = append(builder.targets, unitTests)
 		allUnitTests = append(allUnitTests, unitTests)
 
-		coverage.InputPaths = append(coverage.InputPaths, fmt.Sprintf("coverage-%s.txt", unitTests.Name()))
+		coverage.AddDiscoveredInputs(fmt.Sprintf("coverage-%s.txt", unitTests.Name()))
 	}
 
 	builder.targets = append(builder.targets, coverage)

--- a/internal/project/auto/integration_tests.go
+++ b/internal/project/auto/integration_tests.go
@@ -5,7 +5,12 @@
 package auto
 
 import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
 	"github.com/siderolabs/gen/maps"
+	"github.com/siderolabs/gen/xslices"
 
 	"github.com/siderolabs/kres/internal/project/common"
 	"github.com/siderolabs/kres/internal/project/golang"
@@ -31,7 +36,17 @@ func (builder *builder) BuildIntegrationTests() error {
 	}
 
 	for _, spec := range integrationTests.Tests {
-		build := golang.NewBuild(builder.meta, spec.Name, spec.Path, "go test -c -covermode=atomic")
+		build := golang.NewBuild(builder.meta, spec.Name, spec.Path,
+			fmt.Sprintf(
+				"go test -c -covermode=atomic -coverpkg=%s",
+				strings.Join(
+					xslices.Map(builder.meta.CanonicalPaths, func(s string) string {
+						return filepath.Join(s, "/...")
+					}),
+					",",
+				),
+			),
+		)
 
 		build.Outputs = maps.Map(spec.Outputs, func(k string, m map[string]string) (string, golang.CompileConfig) {
 			return k, golang.CompileConfig(m)

--- a/internal/project/service/codecov.go
+++ b/internal/project/service/codecov.go
@@ -25,6 +25,7 @@ type CodeCov struct {
 
 	meta *meta.Options
 
+	discoveredPaths []string
 	InputPaths      []string `yaml:"inputPaths"`
 	TargetThreshold int      `yaml:"targetThreshold"`
 	Enabled         bool     `yaml:"enabled"`
@@ -40,6 +41,11 @@ func NewCodeCov(meta *meta.Options) *CodeCov {
 		Enabled:         true,
 		TargetThreshold: 50,
 	}
+}
+
+// AddDiscoveredInputs sets automatically discovered codecov.txt files.
+func (coverage *CodeCov) AddDiscoveredInputs(inputs ...string) {
+	coverage.discoveredPaths = append(coverage.discoveredPaths, inputs...)
 }
 
 // CompileDrone implements drone.Compiler.
@@ -62,7 +68,7 @@ func (coverage *CodeCov) CompileGitHubWorkflow(output *ghworkflow.Output) error 
 		return nil
 	}
 
-	paths := xslices.Map(coverage.InputPaths, func(path string) string {
+	paths := xslices.Map(append(coverage.discoveredPaths, coverage.InputPaths...), func(path string) string {
 		return fmt.Sprintf("%s/%s", coverage.meta.ArtifactsPath, path)
 	})
 


### PR DESCRIPTION
Use all canonical module paths to generate `coverpkg`.