### PR TITLE
feat: remove `-v` and `-count 1` from unit tests run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-06-02T14:41:29Z by kres 9f64b0d-dirty.
+# Generated on 2025-07-09T10:43:42Z by kres 2eb6622c-dirty.
 
 ARG TOOLCHAIN
 
@@ -84,13 +84,13 @@ RUN --mount=type=cache,target=/root/.cache/go-build,id=kres/root/.cache/go-build
 FROM base AS unit-tests-race
 WORKDIR /src
 ARG TESTPKGS
-RUN --mount=type=cache,target=/root/.cache/go-build,id=kres/root/.cache/go-build --mount=type=cache,target=/go/pkg,id=kres/go/pkg --mount=type=cache,target=/tmp,id=kres/tmp CGO_ENABLED=1 go test -v -race -count 1 ${TESTPKGS}
+RUN --mount=type=cache,target=/root/.cache/go-build,id=kres/root/.cache/go-build --mount=type=cache,target=/go/pkg,id=kres/go/pkg --mount=type=cache,target=/tmp,id=kres/tmp CGO_ENABLED=1 go test -race ${TESTPKGS}
 
 # runs unit-tests
 FROM base AS unit-tests-run
 WORKDIR /src
 ARG TESTPKGS
-RUN --mount=type=cache,target=/root/.cache/go-build,id=kres/root/.cache/go-build --mount=type=cache,target=/go/pkg,id=kres/go/pkg --mount=type=cache,target=/tmp,id=kres/tmp go test -v -covermode=atomic -coverprofile=coverage.txt -coverpkg=${TESTPKGS} -count 1 ${TESTPKGS}
+RUN --mount=type=cache,target=/root/.cache/go-build,id=kres/root/.cache/go-build --mount=type=cache,target=/go/pkg,id=kres/go/pkg --mount=type=cache,target=/tmp,id=kres/tmp go test -covermode=atomic -coverprofile=coverage.txt -coverpkg=${TESTPKGS} ${TESTPKGS}
 
 FROM embed-generate AS embed-abbrev-generate
 WORKDIR /src


### PR DESCRIPTION
Disable `-v` and `-count 1` by default. They can be re-enabled if needed via:

```
kind: golang.UnitTests
name: unit-tests
spec:
  verbose: true
  count: 1
```