### PR TITLE
fix: checksum sign step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-07-11T14:48:24Z by kres 17000452-dirty.
+# Generated on 2025-07-22T16:29:55Z by kres b869533-dirty.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -119,7 +119,7 @@ jobs:
       - name: Sign artifacts
         if: startsWith(github.ref, 'refs/tags/')
         run: |
-          find _out -type f -name _out/kres-* -exec cosign sign-blob --yes --output {}.sig {} \;
+          find _out -type f -name _out/kres-* -exec cosign sign-blob --yes --output-signature {}.sig {} \;
       - name: Generate Checksums
         if: startsWith(github.ref, 'refs/tags/')
         run: |

--- a/internal/project/common/gh_workflow.go
+++ b/internal/project/common/gh_workflow.go
@@ -291,7 +291,7 @@ func (gh *GHWorkflow) CompileGitHubWorkflow(o *ghworkflow.Output) error {
 					jobDef.Steps = append(jobDef.Steps, cosignStep)
 
 					signCommands := xslices.Map(artifacts, func(artifact string) string {
-						return fmt.Sprintf("cosign sign-blob --output %s.sig --yes %s", artifact, artifact)
+						return fmt.Sprintf("cosign sign-blob --output-signature %s.sig --yes %s", artifact, artifact)
 					})
 
 					signStep := ghworkflow.Step("Sign artifacts").
@@ -321,8 +321,9 @@ func (gh *GHWorkflow) CompileGitHubWorkflow(o *ghworkflow.Output) error {
 
 					if step.ReleaseStep.GenerateSignatures {
 						checkSumSignCommands := []string{
-							"cosign sign-blob --output sha256sum.txt.sig --yes sha256sum.txt",
-							"cosign sign-blob --output sha512sum.txt.sig --yes sha512sum.txt",
+							fmt.Sprintf("cd %s", step.ReleaseStep.BaseDirectory),
+							"cosign sign-blob --output-signature sha256sum.txt.sig --yes sha256sum.txt",
+							"cosign sign-blob --output-signature sha512sum.txt.sig --yes sha512sum.txt",
 						}
 
 						signStep := ghworkflow.Step("Sign checksums").

--- a/internal/project/common/release.go
+++ b/internal/project/common/release.go
@@ -103,7 +103,7 @@ func (release *Release) CompileGitHubWorkflow(output *ghworkflow.Output) error {
 			}
 
 			signCommands := xslices.Map(artifacts, func(artifact string) string {
-				return fmt.Sprintf("find %s -type f -name %s -exec cosign sign-blob --yes --output {}.sig {} \\;", release.meta.ArtifactsPath, artifact)
+				return fmt.Sprintf("find %s -type f -name %s -exec cosign sign-blob --yes --output-signature {}.sig {} \\;", release.meta.ArtifactsPath, artifact)
 			})
 
 			signStep := ghworkflow.Step("Sign artifacts").


### PR DESCRIPTION
There was a missing `cd _out` which breaks it.

Also use `--output-signature` flag, as `--output` got deprecated.