### PR TITLE
feat: include `frontend/public` dir into the docker build

### DIFF
--- a/internal/project/auto/js.go
+++ b/internal/project/auto/js.go
@@ -59,6 +59,7 @@ func (builder *builder) DetectJS() (bool, error) {
 			filepath.Join(srcDir, "*.ts"),
 			filepath.Join(srcDir, "*.html"),
 			filepath.Join(srcDir, "*.ico"),
+			filepath.Join(srcDir, "public"),
 		)
 	}
 

--- a/internal/project/js/toolchain.go
+++ b/internal/project/js/toolchain.go
@@ -5,6 +5,7 @@
 package js
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -142,6 +143,10 @@ func (toolchain *Toolchain) CompileDockerfile(output *dockerfile.Output) error {
 		Step(step.Copy(filepath.Join(toolchain.sourceDir, "*.ts"), "./")).
 		Step(step.Copy(filepath.Join(toolchain.sourceDir, "*.js"), "./")).
 		Step(step.Copy(filepath.Join(toolchain.sourceDir, "*.ico"), "./"))
+
+	if _, err := os.Stat(filepath.Join(toolchain.sourceDir, "public")); err == nil {
+		base.Step(step.Copy(filepath.Join(toolchain.sourceDir, "public"), "./"))
+	}
 
 	for _, directory := range toolchain.meta.JSDirectories {
 		dest := strings.TrimLeft(directory, toolchain.sourceDir)


### PR DESCRIPTION
In some configuration `Vite` assets can be stored in the `public` dir instead of the `frontend` root.