### PR TITLE
fix: rollack actions-system-info GH action to previous version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-08-18T08:50:17Z by kres b6d38e2-dirty.
+# Generated on 2025-08-21T07:54:01Z by kres 18c31cf-dirty.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -33,7 +33,7 @@ jobs:
     steps:
       - name: gather-system-info
         id: system-info
-        uses: kenchan0130/actions-system-info@v1.4.0
+        uses: kenchan0130/actions-system-info@v1.3.1
         continue-on-error: true
       - name: print-system-info
         run: |

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -108,7 +108,7 @@ const (
 	SlackNotifyActionVersion = "v2"
 	// SystemInfoActionVersion is the version of system info github action.
 	// renovate: datasource=github-releases depName=kenchan0130/actions-system-info
-	SystemInfoActionVersion = "v1.4.0"
+	SystemInfoActionVersion = "v1.3.1"
 	// UploadArtifactActionVersion is the version of upload artifact github action.
 	// renovate: datasource=github-releases extractVersion=^(?<version>v\d+)\.\d+\.\d+$ depName=actions/upload-artifact
 	UploadArtifactActionVersion = "v4"

--- a/internal/output/ghworkflow/gh_workflow_test.go
+++ b/internal/output/ghworkflow/gh_workflow_test.go
@@ -77,7 +77,7 @@ jobs:
     steps:
       - name: gather-system-info
         id: system-info
-        uses: kenchan0130/actions-system-info@v1.4.0
+        uses: kenchan0130/actions-system-info@v1.3.1
         continue-on-error: true
       - name: print-system-info
         run: |


### PR DESCRIPTION
Rollback `kenchan0130/actions-system-info` to v1.3.1 from v1.4.0.
Reason for this is: with v1.4.0 this action started using `node` 24 and this was causing intermittent issues on CI runs.
