### PR TITLE
fix: disable ML-KEM/X25519 in FIPS-140 strict mode

### DIFF
--- a/internal/project/golang/unit_tests.go
+++ b/internal/project/golang/unit_tests.go
@@ -153,7 +153,7 @@ func (tests *UnitTests) CompileDockerfile(output *dockerfile.Output) error {
 					MountCache(filepath.Join(tests.meta.GoPath, "pkg"), tests.meta.GitHubRepository).
 					MountCache("/tmp", tests.meta.GitHubRepository).
 					Env("GOFIPS140", "latest").
-					Env("GODEBUG", "fips140=only")))
+					Env("GODEBUG", "fips140=only,tlsmlkem=0")))
 	}
 
 	return nil


### PR DESCRIPTION
See https://github.com/golang/go/issues/75166

This is a workaround for now with Go 1.25, a proper fix might come from the Go side.