### PR TITLE
feat: add `lint-fmt` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-08-20T08:44:16Z by kres 7a0f25c.
+# Generated on 2025-09-09T11:58:02Z by kres 78a535d-dirty.
 
 # common variables
 
@@ -235,6 +235,9 @@ lint-markdown:  ## Runs markdownlint.
 
 .PHONY: lint
 lint: lint-golangci-lint lint-gofumpt lint-govulncheck lint-markdown  ## Run all linters for the project.
+
+.PHONY: lint-fmt
+lint-fmt: lint-golangci-lint-fmt  ## Run all linter formatters and fix up the source tree.
 
 .PHONY: image-kres
 image-kres:  ## Builds image for kres.

--- a/internal/project/golang/golangcilint.go
+++ b/internal/project/golang/golangcilint.go
@@ -103,3 +103,6 @@ func (lint *GolangciLint) CompileDockerfile(output *dockerfile.Output) error {
 
 	return nil
 }
+
+// LinterHasFmt is implemented by linters that have a formatting step.
+func (lint *GolangciLint) LinterHasFmt() {}

--- a/internal/project/js/eslint.go
+++ b/internal/project/js/eslint.go
@@ -64,3 +64,6 @@ func (lint *EsLint) CompileDockerfile(output *dockerfile.Output) error {
 
 	return nil
 }
+
+// LinterHasFmt is implemented by linters that have a formatting step.
+func (lint *EsLint) LinterHasFmt() {}


### PR DESCRIPTION
It runs all linters which can format code in a row.