### PR TITLE
fix: make JS frontend target attach to the build

### DIFF
--- a/internal/dag/base.go
+++ b/internal/dag/base.go
@@ -4,12 +4,15 @@
 
 package dag
 
+import "slices"
+
 // BaseNode implements core functionality of the node.
 //
 // BaseNode is designed to be included into other types.
 type BaseNode struct { //nolint:govet
-	inputs []Node
-	name   string
+	parents []Node
+	inputs  []Node
+	name    string
 }
 
 // NewBaseNode creates new embeddable BaseNode.
@@ -29,8 +32,24 @@ func (node *BaseNode) Inputs() []Node {
 	return node.inputs
 }
 
+// Parents implements Node interface.
+func (node *BaseNode) Parents() []Node {
+	return node.parents
+}
+
+// AddParent implements Node interface.
+func (node *BaseNode) AddParent(parent Node) {
+	if !slices.Contains(node.parents, parent) {
+		node.parents = append(node.parents, parent)
+	}
+}
+
 // AddInput implements Node interface.
 func (node *BaseNode) AddInput(input ...Node) {
+	for _, n := range input {
+		n.AddParent(node)
+	}
+
 	node.inputs = append(node.inputs, input...)
 }
 

--- a/internal/dag/node.go
+++ b/internal/dag/node.go
@@ -14,7 +14,9 @@ import (
 type Node interface {
 	Name() string
 	Inputs() []Node
+	Parents() []Node
 	AddInput(...Node)
+	AddParent(Node)
 }
 
 // NodeCondition checks the node for a specific condition.

--- a/internal/project/golang/toolchain.go
+++ b/internal/project/golang/toolchain.go
@@ -271,14 +271,6 @@ func (toolchain *Toolchain) CompileDockerfile(output *dockerfile.Output) error {
 		base.Step(step.Copy("./"+file, "./"+file))
 	}
 
-	// build chain of gen containers.
-	inputs := dag.GatherMatchingInputs(toolchain, dag.Implements[dockerfile.Generator]())
-	for _, input := range inputs {
-		for _, path := range input.(dockerfile.Generator).GetArtifacts() { //nolint:forcetypeassert,errcheck
-			base.Step(step.Copy(path, "./"+strings.Trim(path, "/")).From(input.Name()))
-		}
-	}
-
 	base.Step(step.Script(`go list -mod=readonly all >/dev/null`).MountCache(filepath.Join(toolchain.meta.GoPath, "pkg"), toolchain.meta.GitHubRepository))
 
 	return nil


### PR DESCRIPTION
Previously it was attached to the `base`, so it got into steps like `golangci-lint` which don't care about it, but also it gets exported back to the source tree via `make lint-golangci-lint-fmt`.

Re-attach it to the build step (where we actually need it).

Another solution is to make it part of `make generate` and keep it part of the source tree.