### PR TITLE
feat: use runner groups

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-08-21T07:54:01Z by kres 18c31cf-dirty.
+# Generated on 2025-09-11T00:53:48Z by kres ba56673-dirty.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -27,8 +27,7 @@ jobs:
       packages: write
       pull-requests: read
     runs-on:
-      - self-hosted
-      - generic
+      group: generic
     if: (!startsWith(github.head_ref, 'renovate/') && !startsWith(github.head_ref, 'dependabot/'))
     steps:
       - name: gather-system-info

--- a/.github/workflows/slack-notify-ci-failure.yaml
+++ b/.github/workflows/slack-notify-ci-failure.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-08-05T08:47:34Z by kres 95bf7d7-dirty.
+# Generated on 2025-09-11T08:31:52Z by kres cb448bc-dirty.
 
 "on":
   workflow_run:
@@ -14,8 +14,7 @@ name: slack-notify-failure
 jobs:
   slack-notify:
     runs-on:
-      - self-hosted
-      - generic
+      group: generic
     if: github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.event != 'pull_request'
     steps:
       - name: Slack Notify

--- a/.github/workflows/slack-notify.yaml
+++ b/.github/workflows/slack-notify.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-08-04T12:39:36Z by kres 5fb5b90-dirty.
+# Generated on 2025-09-11T08:31:52Z by kres cb448bc-dirty.
 
 "on":
   workflow_run:
@@ -12,8 +12,7 @@ name: slack-notify
 jobs:
   slack-notify:
     runs-on:
-      - self-hosted
-      - generic
+      group: generic
     if: github.event.workflow_run.conclusion != 'skipped'
     steps:
       - name: Get PR number

--- a/internal/output/ghworkflow/gh_workflow_test.go
+++ b/internal/output/ghworkflow/gh_workflow_test.go
@@ -39,6 +39,7 @@ func (suite *GHWorkflowSuite) TestDefaultWorkflows() {
 	)
 
 	output := ghworkflow.NewOutput(defaultBranch, withDefaultJob, withStaleJob, customSlackChannel) //nolint:typecheck
+	output.SetRunnerGroup("generic")
 
 	var buf bytes.Buffer
 
@@ -72,7 +73,8 @@ jobs:
       issues: read
       packages: write
       pull-requests: read
-    runs-on: []
+    runs-on:
+      group: generic
     if: (!startsWith(github.head_ref, 'renovate/') && !startsWith(github.head_ref, 'dependabot/'))
     steps:
       - name: gather-system-info

--- a/internal/project/helm/build.go
+++ b/internal/project/helm/build.go
@@ -134,10 +134,7 @@ func (helm *Build) CompileGitHubWorkflow(output *ghworkflow.Output) error {
 		Jobs: map[string]*ghworkflow.Job{
 			"default": {
 				Permissions: jobPermissions,
-				RunsOn: []string{
-					ghworkflow.HostedRunner,
-					ghworkflow.GenericRunner,
-				},
+				RunsOn:      ghworkflow.NewRunsOnGroupLabel(ghworkflow.GenericRunner, ""),
 				Steps: slices.Concat(
 					ghworkflow.CommonSteps(),
 					[]*ghworkflow.JobStep{

--- a/internal/project/pkgfile/build.go
+++ b/internal/project/pkgfile/build.go
@@ -261,13 +261,8 @@ func (pkgfile *Build) CompileGitHubWorkflow(output *ghworkflow.Output) error {
 			"labels": "${{ steps.retrieve-pr-labels.outputs.result }}",
 		})
 
-		runnerLabels := []string{
-			ghworkflow.HostedRunner,
-			ghworkflow.PkgsRunner,
-		}
-
 		output.AddJob("reproducibility", &ghworkflow.Job{
-			RunsOn: runnerLabels,
+			RunsOn: ghworkflow.NewRunsOnGroupLabel(ghworkflow.PkgsRunner, ""),
 			If:     "contains(fromJSON(needs.default.outputs.labels), 'integration/reproducibility')",
 			Needs:  []string{"default"},
 			Steps:  ghworkflow.DefaultPkgsSteps(),
@@ -293,7 +288,7 @@ func (pkgfile *Build) CompileGitHubWorkflow(output *ghworkflow.Output) error {
 				},
 				Jobs: map[string]*ghworkflow.Job{
 					"reproducibility": {
-						RunsOn: runnerLabels,
+						RunsOn: ghworkflow.NewRunsOnGroupLabel(ghworkflow.PkgsRunner, ""),
 						Steps: append(
 							ghworkflow.DefaultPkgsSteps(),
 							ghworkflow.Step("reproducibility-test").SetMakeStep("reproducibility-test"),


### PR DESCRIPTION
Use runner groups for GitHub action to work with GHA runner scale sets.

Support `string`, `array` and `object` types for `runs-on` github action workflow syntax.