### PR TITLE
fix: don't enforce lint context always

### DIFF
--- a/internal/project/auto/builder.go
+++ b/internal/project/auto/builder.go
@@ -23,7 +23,7 @@ type builder struct {
 	commonInputs []dag.Node
 
 	lintInputs []dag.Node
-	lintTarget dag.Node
+	lintTarget *common.Lint
 
 	targets []dag.Node
 }
@@ -125,6 +125,7 @@ func (builder *builder) build() error {
 	}
 
 	if len(builder.lintInputs) > 0 {
+		builder.lintTarget.Activate()
 		builder.lintTarget.AddInput(builder.lintInputs...)
 
 		builder.targets = append(builder.targets, builder.lintTarget)

--- a/internal/project/common/lint.go
+++ b/internal/project/common/lint.go
@@ -25,10 +25,6 @@ type Lint struct { //nolint:govet
 
 // NewLint initializes Lint.
 func NewLint(meta *meta.Options) *Lint {
-	if !slices.Contains(meta.ExtraEnforcedContexts, "lint") {
-		meta.ExtraEnforcedContexts = append(meta.ExtraEnforcedContexts, "lint")
-	}
-
 	return &Lint{
 		BaseNode: dag.NewBaseNode("lint"),
 
@@ -43,6 +39,13 @@ func (lint *Lint) CompileDrone(output *drone.Output) error {
 	)
 
 	return nil
+}
+
+// Activate marks the linter as active.
+func (lint *Lint) Activate() {
+	if !slices.Contains(lint.meta.ExtraEnforcedContexts, "lint") {
+		lint.meta.ExtraEnforcedContexts = append(lint.meta.ExtraEnforcedContexts, "lint")
+	}
 }
 
 // CompileGitHubWorkflow implements ghworkflow.Compiler.


### PR DESCRIPTION
It might be that we create the target, but never consume it.

Ensure that the context is only enforced if lint is active.