### PR TITLE
fix: always retrieve PR labels on default job

### DIFF
--- a/internal/project/custom/custom.go
+++ b/internal/project/custom/custom.go
@@ -366,8 +366,8 @@ func (step *Step) CompileGitHubWorkflow(output *ghworkflow.Output) error {
 
 	if len(step.GHAction.Jobs) > 0 {
 		if !output.CheckIfStepExists("default", "retrieve-pr-labels") {
-			steps = append(
-				steps,
+			output.AddStep(
+				"default",
 				ghworkflow.Step("Retrieve PR labels").
 					SetID("retrieve-pr-labels").
 					SetUses("actions/github-script@"+config.GitHubScriptActionVersion).


### PR DESCRIPTION
Always retrieve PR labels on default job
