### PR TITLE
feat: add dispatchable actions

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -54,7 +54,7 @@
             "matchPackageNames": [
                 "actions/checkout",
                 "docker/login-action",
-                "crazy-max/ghaction-github-release",
+                "softprops/action-gh-release",
                 "docker/setup-buildx-action",
                 "slackapi/slack-github-action"
             ]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -116,7 +116,7 @@ jobs:
           make release-notes
       - name: Release
         if: startsWith(github.ref, 'refs/tags/')
-        uses: crazy-max/ghaction-github-release@v2
+        uses: softprops/action-gh-release@v2
         with:
           body_path: _out/RELEASE_NOTES.md
           draft: "true"

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -86,7 +86,7 @@ spec:
     - matchPackageNames:
         - actions/checkout
         - docker/login-action
-        - crazy-max/ghaction-github-release
+        - softprops/action-gh-release
         - docker/setup-buildx-action
         - slackapi/slack-github-action
       versioning: 'regex:^v(?<major>\d+)'

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -92,7 +92,7 @@ const (
 	// renovate: datasource=go depName=github.com/siderolabs/protoc-gen-grpc-gateway-ts
 	ProtobufTSGatewayVersion = "v1.2.1"
 	// ReleaseActionVersion is the version of release github action.
-	// renovate: datasource=github-releases extractVersion=^(?<version>v\d+)\.\d+\.\d+$ depName=crazy-max/ghaction-github-release
+	// renovate: datasource=github-releases extractVersion=^(?<version>v\d+)\.\d+\.\d+$ depName=softprops/action-gh-release
 	ReleaseActionVersion = "v2"
 	// SentencesPerLineVersion is the version of sentences-per-line.
 	// renovate: datasource=npm depName=sentences-per-line

--- a/internal/project/common/gh_workflow.go
+++ b/internal/project/common/gh_workflow.go
@@ -19,14 +19,15 @@ import (
 
 // Job defines options for jobs.
 type Job struct {
-	Name          string         `yaml:"name"`
 	BuildxOptions *BuildxOptions `yaml:"buildxOptions,omitempty"`
+	Name          string         `yaml:"name"`
+	RunnerGroup   string         `yaml:"runnerGroup,omitempty"`
 	Conditions    []string       `yaml:"conditions,omitempty"`
 	Crons         []string       `yaml:"crons,omitempty"`
 	Depends       []string       `yaml:"depends,omitempty"`
-	RunnerGroup   string         `yaml:"runnerGroup,omitempty"`
 	TriggerLabels []string       `yaml:"triggerLabels,omitempty"`
 	Steps         []Step         `yaml:"steps,omitempty"`
+	Dispatchable  bool           `yaml:"dispatchable"`
 	SOPS          bool           `yaml:"sops"`
 }
 
@@ -288,7 +289,7 @@ func (gh *GHWorkflow) CompileGitHubWorkflow(o *ghworkflow.Output) error {
 				})
 
 				releaseStep := ghworkflow.Step(step.Name).
-					SetUses("crazy-max/ghaction-github-release@"+config.ReleaseActionVersion).
+					SetUses("softprops/action-gh-release@"+config.ReleaseActionVersion).
 					SetWith("body_path", filepath.Join(step.ReleaseStep.BaseDirectory, step.ReleaseStep.ReleaseNotes)).
 					SetWith("draft", "true").
 					SetWith("files", strings.Join(artifacts, "\n"))
@@ -464,7 +465,7 @@ func (gh *GHWorkflow) CompileGitHubWorkflow(o *ghworkflow.Output) error {
 			)
 		}
 
-		o.AddJob(job.Name, jobDef)
+		o.AddJob(job.Name, job.Dispatchable, jobDef)
 	}
 
 	return nil

--- a/internal/project/common/release.go
+++ b/internal/project/common/release.go
@@ -72,7 +72,7 @@ func (release *Release) CompileGitHubWorkflow(output *ghworkflow.Output) error {
 	steps := []*ghworkflow.JobStep{}
 
 	releaseStep := ghworkflow.Step("Release").
-		SetUses("crazy-max/ghaction-github-release@"+config.ReleaseActionVersion).
+		SetUses("softprops/action-gh-release@"+config.ReleaseActionVersion).
 		SetWith("body_path", filepath.Join(release.meta.ArtifactsPath, "RELEASE_NOTES.md")).
 		SetWith("draft", "true")
 

--- a/internal/project/custom/custom.go
+++ b/internal/project/custom/custom.go
@@ -517,7 +517,7 @@ func (step *Step) CompileGitHubWorkflow(output *ghworkflow.Output) error {
 			)
 		}
 
-		output.AddJob(job.Name, &ghworkflow.Job{
+		output.AddJob(job.Name, false, &ghworkflow.Job{
 			RunsOn: ghworkflow.NewRunsOnGroupLabel(job.RunnerGroup, ""),
 			If:     strings.Join(conditions, " || "),
 			Needs:  []string{"default"},

--- a/internal/project/meta/meta.go
+++ b/internal/project/meta/meta.go
@@ -83,8 +83,11 @@ type Options struct { //nolint:govet
 	// CIProvider specifies the CI provider. Currently drone/ghaction is supported.
 	CIProvider string
 
+	// CompileGithubWorkflowsOnly indicates that only GitHub workflows should be compiled.
 	CompileGithubWorkflowsOnly bool
-	ExtraEnforcedContexts      []string
+
+	// EnforcedContexts is the list of required status checks for GitHub branch protection.
+	ExtraEnforcedContexts []string
 
 	// ContainerImageFrontend is the default frontend container image.
 	ContainerImageFrontend string

--- a/internal/project/pkgfile/build.go
+++ b/internal/project/pkgfile/build.go
@@ -267,7 +267,7 @@ func (pkgfile *Build) CompileGitHubWorkflow(output *ghworkflow.Output) error {
 			"labels": "${{ steps.retrieve-pr-labels.outputs.result }}",
 		})
 
-		output.AddJob("reproducibility", &ghworkflow.Job{
+		output.AddJob("reproducibility", false, &ghworkflow.Job{
 			RunsOn: ghworkflow.NewRunsOnGroupLabel(ghworkflow.PkgsRunner, ""),
 			If:     "contains(fromJSON(needs.default.outputs.labels), 'integration/reproducibility')",
 			Needs:  []string{"default"},


### PR DESCRIPTION
Allow defining GH Action Workflow jobs as dispatchable meaning they will run only on a workflow_dispatch event.

Example usage:
- https://github.com/siderolabs/talos/pull/11875

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
