### PR TITLE
feat: add inputs to gh_workflow

### DIFF
--- a/internal/output/ghworkflow/gh_workflow.go
+++ b/internal/output/ghworkflow/gh_workflow.go
@@ -274,7 +274,7 @@ func (o *Output) AddWorkflow(name string, workflow *Workflow) {
 }
 
 // AddJob adds job to the default workflow.
-func (o *Output) AddJob(name string, dispatch bool, job *Job) {
+func (o *Output) AddJob(name string, dispatch bool, job *Job, inputs []string) {
 	workflowName := CiWorkflow
 	if dispatch {
 		workflowName = DispatchableWorkflow
@@ -284,14 +284,15 @@ func (o *Output) AddJob(name string, dispatch bool, job *Job) {
 				Name: "dispatch",
 				On: On{
 					WorkFlowDispatch: &WorkFlowDispatch{
-						Inputs: map[string]WorkFlowDispatchInput{
-							"input": {
-								Description: "Input to pass to dispatched workflow",
-								Type:        "string",
-							},
-						},
+						Inputs: map[string]WorkFlowDispatchInput{},
 					},
 				},
+			}
+		}
+
+		for _, input := range inputs {
+			o.workflows[workflowName].Inputs[input] = WorkFlowDispatchInput{
+				Type: "string",
 			}
 		}
 	}

--- a/internal/project/common/gh_workflow.go
+++ b/internal/project/common/gh_workflow.go
@@ -27,6 +27,7 @@ type Job struct {
 	Depends       []string       `yaml:"depends,omitempty"`
 	TriggerLabels []string       `yaml:"triggerLabels,omitempty"`
 	Steps         []Step         `yaml:"steps,omitempty"`
+	Inputs        []string       `yaml:"inputs,omitempty"`
 	Dispatchable  bool           `yaml:"dispatchable"`
 	SOPS          bool           `yaml:"sops"`
 }
@@ -465,7 +466,7 @@ func (gh *GHWorkflow) CompileGitHubWorkflow(o *ghworkflow.Output) error {
 			)
 		}
 
-		o.AddJob(job.Name, job.Dispatchable, jobDef)
+		o.AddJob(job.Name, job.Dispatchable, jobDef, job.Inputs)
 	}
 
 	return nil

--- a/internal/project/custom/custom.go
+++ b/internal/project/custom/custom.go
@@ -522,7 +522,7 @@ func (step *Step) CompileGitHubWorkflow(output *ghworkflow.Output) error {
 			If:     strings.Join(conditions, " || "),
 			Needs:  []string{"default"},
 			Steps:  defaultSteps,
-		})
+		}, nil)
 
 		var steps []*ghworkflow.JobStep
 

--- a/internal/project/pkgfile/build.go
+++ b/internal/project/pkgfile/build.go
@@ -272,7 +272,7 @@ func (pkgfile *Build) CompileGitHubWorkflow(output *ghworkflow.Output) error {
 			If:     "contains(fromJSON(needs.default.outputs.labels), 'integration/reproducibility')",
 			Needs:  []string{"default"},
 			Steps:  ghworkflow.DefaultPkgsSteps(),
-		})
+		}, nil)
 		output.AddStep("reproducibility", ghworkflow.Step("reproducibility-test").SetMakeStep("reproducibility-test"))
 
 		output.AddSlackNotify("weekly")


### PR DESCRIPTION
Allow defining inputs by name in the dispatchable workflows.

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>