### PR TITLE
feat: support github matrix jobs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-08T11:05:36Z by kres 5b81a3a-dirty.
+# Generated on 2026-04-17T08:55:31Z by kres 359ab16-dirty.
 
 # common variables
 
@@ -178,10 +178,10 @@ local-%:  ## Builds the specified target defined in the Dockerfile using the loc
 	  done'
 
 .PHONY: check-dirty
-check-dirty:
+check-dirty: generate
 	@if test -n "`git status --porcelain`"; then echo "Source tree is dirty"; git status; git diff; exit 1 ; fi
 
-generate:  ## Generate .proto definitions.
+generate: helm-plugin-install  ## Generate .proto definitions.
 	@$(MAKE) local-$@ DEST=./
 	@TAG=$$(cat internal/version/data/tag); \
 	if echo "$$TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$$'; then \

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -26,16 +26,12 @@ const (
 	// renovate: datasource=github-tags depName=codecov/codecov-action
 	CodeCovActionVersion = "v6.0.0"
 	CodeCovActionRef     = "57e3a136b779b570ffcdbf80b3bdc90e7fab3de2"
-	// CosignInstallActionVersion is the version of cosign install github action.
-	// renovate: datasource=github-tags depName=sigstore/cosign-installer
-	CosignInstallActionVersion = "v4.1.1"
-	CosignInstallActionRef     = "cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003"
 	// DeepCopyVersion is the version of deepcopy.
 	// renovate: datasource=go depName=github.com/siderolabs/deep-copy
 	DeepCopyVersion = "v0.5.8"
 	// DindContainerImageVersion is the version of the dind container image.
 	// renovate: datasource=docker versioning=docker depName=docker
-	DindContainerImageVersion = "29.3-dind"
+	DindContainerImageVersion = "29.4-dind"
 	// DockerfileFrontendImageVersion is the version of the dockerfile frontend image.
 	// renovate: datasource=docker versioning=docker depName=docker/dockerfile-upstream
 	DockerfileFrontendImageVersion = "1.23.0-labs"
@@ -74,10 +70,6 @@ const (
 	// GrpcGoVersion is the version of grpc.
 	// renovate: datasource=go depName=google.golang.org/grpc/cmd/protoc-gen-go-grpc
 	GrpcGoVersion = "v1.6.1"
-	// HelmSetupActionVersion is the version of helm setup github action.
-	// renovate: datasource=github-tags depName=Azure/setup-helm
-	HelmSetupActionVersion = "v5.0.0"
-	HelmSetupActionRef     = "dda3372f752e03dde6b3237bc9431cdc2f7a02a2"
 	// HelmUnitTestVersion is the version of helm unit test plugin.
 	// renovate: datasource=github-tags depName=helm-unittest/helm-unittest
 	HelmUnitTestVersion = "v1.0.3"

--- a/internal/output/ghworkflow/gh_workflow.go
+++ b/internal/output/ghworkflow/gh_workflow.go
@@ -11,6 +11,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 
@@ -681,6 +683,12 @@ func (step *JobStep) SetConditionOnlyOnBranch(name string) *JobStep {
 // SetConditions sets step conditions.
 func (step *JobStep) SetConditions(conditions ...string) error {
 	for _, condition := range conditions {
+		if strings.HasPrefix(condition, "matrix.") {
+			step.appendIf(fmt.Sprintf("${{ %s }}", condition))
+
+			continue
+		}
+
 		switch condition {
 		case "except-pull-request":
 			step.appendIf("github.event_name != 'pull_request'")
@@ -722,6 +730,12 @@ func (job *Job) appendIf(condition string) {
 // SetConditions sets job conditions.
 func (job *Job) SetConditions(conditions ...string) error {
 	for _, condition := range conditions {
+		if strings.HasPrefix(condition, "matrix.") {
+			job.appendIf(fmt.Sprintf("${{ %s }}", condition))
+
+			continue
+		}
+
 		switch condition {
 		case "except-pull-request":
 			job.appendIf("github.event_name != 'pull_request'")
@@ -754,6 +768,50 @@ func (job *Job) SetConditions(conditions ...string) error {
 // Compile implements [output.TypedWriter] interface.
 func (o *Output) Compile(compiler Compiler) error {
 	return compiler.CompileGitHubWorkflow(o)
+}
+
+// Generate extends FileAdapter.Generate by removing stale -cron.yaml and
+// -triggered.yaml files in .github/workflows/ that are no longer part of the
+// current configuration.
+func (o *Output) Generate() error {
+	if err := o.FileAdapter.Generate(); err != nil {
+		return err
+	}
+
+	// Build a set of every workflow file this run manages.
+	managed := make(map[string]struct{}, len(o.workflows))
+	for f := range o.workflows {
+		managed[f] = struct{}{}
+	}
+
+	entries, err := os.ReadDir(workflowDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+
+		return err
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		name := entry.Name()
+		if !strings.HasSuffix(name, "-cron.yaml") && !strings.HasSuffix(name, "-triggered.yaml") {
+			continue
+		}
+
+		fullPath := filepath.Join(workflowDir, name)
+		if _, ok := managed[fullPath]; !ok {
+			if err := os.Remove(fullPath); err != nil && !os.IsNotExist(err) {
+				return err
+			}
+		}
+	}
+
+	return nil
 }
 
 // Filenames implements output.FileWriter interface.

--- a/internal/output/ghworkflow/gh_workflow_test.go
+++ b/internal/output/ghworkflow/gh_workflow_test.go
@@ -6,16 +6,39 @@ package ghworkflow_test
 
 import (
 	"bytes"
-	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/siderolabs/kres/internal/output"
 	"github.com/siderolabs/kres/internal/output/ghworkflow"
 )
+
+// set to true to regenerate testdata golden files.
+var update = false //nolint:gochecknoglobals
+
+func assertGolden(t testing.TB, filename string, got []byte) {
+	t.Helper()
+
+	path := filepath.Join("testdata", filepath.FromSlash(t.Name()), filepath.Base(filename))
+
+	if update {
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, got, 0o600))
+
+		return
+	}
+
+	want, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, string(want), string(got))
+}
 
 type GHWorkflowSuite struct {
 	suite.Suite
@@ -38,89 +61,67 @@ func (suite *GHWorkflowSuite) TestDefaultWorkflows() {
 		customSlackChannel = "ci-failure-custom"
 	)
 
-	output := ghworkflow.NewOutput(defaultBranch, withDefaultJob, withStaleJob, customSlackChannel) //nolint:typecheck
-	output.SetRunnerGroup(ghworkflow.GenericRunner)
+	o := ghworkflow.NewOutput(defaultBranch, withDefaultJob, withStaleJob, customSlackChannel) //nolint:typecheck
+	o.SetRunnerGroup(ghworkflow.GenericRunner)
+
+	var ciBuf bytes.Buffer
+
+	suite.Require().NoError(o.GenerateFile(ghworkflow.CiWorkflow, &ciBuf))
+	assertGolden(suite.T(), ghworkflow.CiWorkflow, ciBuf.Bytes())
+
+	var slackBuf bytes.Buffer
+
+	suite.Require().NoError(o.GenerateFile(ghworkflow.SlackCIFailureWorkflow, &slackBuf))
+	assertGolden(suite.T(), ghworkflow.SlackCIFailureWorkflow, slackBuf.Bytes())
+}
+
+func TestMatrixStrategy(t *testing.T) {
+	output.PreambleTimestamp, _ = time.Parse(time.RFC3339, strings.ReplaceAll(time.RFC3339, "07:00", "")) //nolint:errcheck
+	output.PreambleCreator = "test"
+
+	// Build a step that has a matrix condition and a matrix-interpolated command.
+	buildStep := ghworkflow.Step("build").
+		SetMakeStep("build-${{ matrix.track }}")
+
+	err := buildStep.SetConditions("only-on-schedule", "matrix.buildEnforcing")
+	require.NoError(t, err)
+
+	// Build a triggered workflow job with a 2-entry matrix.
+	job := &ghworkflow.Job{
+		If:     "github.event.workflow_run.conclusion == 'success'",
+		RunsOn: ghworkflow.NewRunsOnGroupLabel("large", ""),
+		Strategy: &ghworkflow.Strategy{
+			MaxParallel: 2,
+			Matrix: &ghworkflow.StrategyMatrix{
+				Include: []map[string]string{
+					{"track": "0"},
+					{"track": "1", "buildEnforcing": "true"},
+				},
+			},
+		},
+		Steps: []*ghworkflow.JobStep{buildStep},
+	}
+
+	o := ghworkflow.NewOutput("main", false, false, "")
+	o.AddWorkflow("integration-provision-triggered", &ghworkflow.Workflow{
+		Name: "integration-provision-triggered",
+		Concurrency: ghworkflow.Concurrency{
+			Group:            "${{ github.head_ref || github.run_id }}",
+			CancelInProgress: true,
+		},
+		On: ghworkflow.On{
+			WorkFlowRun: ghworkflow.WorkFlowRun{
+				Workflows: []string{"artifacts-cron"},
+				Types:     []string{"completed"},
+			},
+		},
+		Jobs: map[string]*ghworkflow.Job{
+			ghworkflow.DefaultJobName: job,
+		},
+	})
 
 	var buf bytes.Buffer
 
-	err := output.GenerateFile(ghworkflow.CiWorkflow, &buf)
-	suite.Require().NoError(err)
-
-	suite.Equal(`# THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
-#
-# Generated on 2006-01-02T15:04:05Z by test.
-
-concurrency:
-  group: ${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
-"on":
-  push:
-    branches:
-      - main
-      - release-*
-    tags:
-      - v*
-  pull_request:
-    branches:
-      - main
-      - release-*
-name: default
-jobs:
-  default:
-    permissions:
-      actions: read
-      contents: write
-      issues: read
-      packages: write
-      pull-requests: read
-    runs-on:
-      group: generic
-    if: (!startsWith(github.head_ref, 'renovate/') && !startsWith(github.head_ref, 'dependabot/'))
-    steps:
-      - name: gather-system-info
-        id: system-info
-        uses: kenchan0130/actions-system-info@59699597e84e80085a750998045983daa49274c4 # version: v1.4.0
-        continue-on-error: true
-      - name: print-system-info
-        run: |
-          MEMORY_GB=$((${{ steps.system-info.outputs.totalmem }}/1024/1024/1024))
-
-          OUTPUTS=(
-            "CPU Core: ${{ steps.system-info.outputs.cpu-core }}"
-            "CPU Model: ${{ steps.system-info.outputs.cpu-model }}"
-            "Hostname: ${{ steps.system-info.outputs.hostname }}"
-            "NodeName: ${NODE_NAME}"
-            "Kernel release: ${{ steps.system-info.outputs.kernel-release }}"
-            "Kernel version: ${{ steps.system-info.outputs.kernel-version }}"
-            "Name: ${{ steps.system-info.outputs.name }}"
-            "Platform: ${{ steps.system-info.outputs.platform }}"
-            "Release: ${{ steps.system-info.outputs.release }}"
-            "Total memory: ${MEMORY_GB} GB"
-          )
-
-          for OUTPUT in "${OUTPUTS[@]}";do
-            echo "${OUTPUT}"
-          done
-        continue-on-error: true
-      - name: checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # version: v6.0.2
-      - name: Unshallow
-        run: |
-          git fetch --prune --unshallow
-      - name: Set up Docker Buildx
-        id: setup-buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # version: v4.0.0
-        with:
-          driver: remote
-          endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
-        timeout-minutes: 10`,
-		strings.TrimSpace(buf.String()))
-
-	var buf2 bytes.Buffer
-
-	err = output.GenerateFile(ghworkflow.SlackCIFailureWorkflow, &buf2)
-
-	fmt.Print(buf2.String())
-	suite.Require().NoError(err)
-	suite.Contains(buf2.String(), customSlackChannel)
+	require.NoError(t, o.GenerateFile(".github/workflows/integration-provision-triggered.yaml", &buf))
+	assertGolden(t, "integration-provision-triggered.yaml", buf.Bytes())
 }

--- a/internal/output/ghworkflow/testdata/TestGHWorkflowSuite/TestDefaultWorkflows/ci.yaml
+++ b/internal/output/ghworkflow/testdata/TestGHWorkflowSuite/TestDefaultWorkflows/ci.yaml
@@ -1,32 +1,33 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-17T08:55:31Z by kres 359ab16-dirty.
+# Generated on 2006-01-02T15:04:05Z by test.
 
 concurrency:
-  group: helm-${{ github.head_ref || github.run_id }}
+  group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 "on":
   push:
+    branches:
+      - main
+      - release-*
     tags:
       - v*
   pull_request:
     branches:
       - main
       - release-*
-    paths:
-      - test/**
-name: helm
+name: default
 jobs:
   default:
     permissions:
       actions: read
       contents: write
-      id-token: write
       issues: read
       packages: write
       pull-requests: read
     runs-on:
       group: generic
+    if: (!startsWith(github.head_ref, 'renovate/') && !startsWith(github.head_ref, 'dependabot/'))
     steps:
       - name: gather-system-info
         id: system-info
@@ -65,46 +66,3 @@ jobs:
           driver: remote
           endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
         timeout-minutes: 10
-      - name: Login to registry
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # version: v4.1.0
-        with:
-          password: ${{ secrets.GITHUB_TOKEN }}
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-      - name: Lint chart
-        if: github.event_name == 'pull_request'
-        run: |
-          helm lint test/test-helm-chart
-      - name: Template chart
-        if: github.event_name == 'pull_request'
-        run: |
-          helm template -f test/test-helm-chart/ci-values.yaml test-helm-chart test/test-helm-chart
-      - name: Install unit test plugin
-        if: github.event_name == 'pull_request'
-        run: |
-          make helm-plugin-install
-      - name: Unit test chart
-        if: github.event_name == 'pull_request'
-        run: |
-          make chart-unittest
-      - name: Generate schema
-        if: github.event_name == 'pull_request'
-        run: |
-          make chart-gen-schema
-      - name: Generate docs
-        if: github.event_name == 'pull_request'
-        run: |
-          make helm-docs
-      - name: helm login
-        if: startsWith(github.ref, 'refs/tags/')
-        env:
-          HELM_CONFIG_HOME: /var/tmp/.config/helm
-        run: |
-          helm registry login -u ${{ github.repository_owner }} -p ${{ secrets.GITHUB_TOKEN }} ghcr.io
-      - name: Release chart
-        if: startsWith(github.ref, 'refs/tags/')
-        env:
-          HELM_CONFIG_HOME: /var/tmp/.config/helm
-        run: |
-          make helm-release

--- a/internal/output/ghworkflow/testdata/TestGHWorkflowSuite/TestDefaultWorkflows/slack-notify-ci-failure.yaml
+++ b/internal/output/ghworkflow/testdata/TestGHWorkflowSuite/TestDefaultWorkflows/slack-notify-ci-failure.yaml
@@ -1,0 +1,88 @@
+# THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
+#
+# Generated on 2006-01-02T15:04:05Z by test.
+
+"on":
+  workflow_run:
+    workflows:
+      - default
+    types:
+      - completed
+    branches:
+      - main
+name: slack-notify-failure
+jobs:
+  slack-notify:
+    runs-on:
+      group: generic
+    if: github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.event != 'pull_request'
+    steps:
+      - name: Slack Notify
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # version: v3.0.1
+        with:
+          method: chat.postMessage
+          payload: |
+            {
+                "channel": "ci-failure-custom",
+                "text": "${{ github.event.workflow_run.conclusion }} - ${{ github.repository }}",
+                "icon_emoji": "${{ github.event.workflow_run.conclusion == 'success' && ':white_check_mark:' || github.event.workflow_run.conclusion == 'failure' && ':x:' || ':warning:' }}",
+                "username": "GitHub Actions",
+                "attachments": [
+                    {
+                        "blocks": [
+                            {
+                                "fields": [
+                                    {
+                                        "text": "${{ github.event.workflow_run.event == 'pull_request' && format('*Pull Request:* {0} (`{1}`)\n<{2}/pull/{3}|{4}>', github.repository, github.ref_name, github.event.repository.html_url, steps.get-pr-number.outputs.pull_request_number, github.event.workflow_run.display_title) || format('*Build:* {0} (`{1}`)\n<{2}/commit/{3}|{4}>', github.repository, github.ref_name, github.event.repository.html_url, github.sha, github.event.workflow_run.display_title) }}",
+                                        "type": "mrkdwn"
+                                    },
+                                    {
+                                        "text": "*Status:*\n`${{ github.event.workflow_run.conclusion }}`",
+                                        "type": "mrkdwn"
+                                    }
+                                ],
+                                "type": "section"
+                            },
+                            {
+                                "fields": [
+                                    {
+                                        "text": "*Author:*\n`${{ github.actor }}`",
+                                        "type": "mrkdwn"
+                                    },
+                                    {
+                                        "text": "*Event:*\n`${{ github.event.workflow_run.event }}`",
+                                        "type": "mrkdwn"
+                                    }
+                                ],
+                                "type": "section"
+                            },
+                            {
+                                "type": "divider"
+                            },
+                            {
+                                "elements": [
+                                    {
+                                        "text": {
+                                            "text": "Logs",
+                                            "type": "plain_text"
+                                        },
+                                        "type": "button",
+                                        "url": "${{ github.event.workflow_run.html_url }}"
+                                    },
+                                    {
+                                        "text": {
+                                            "text": "Commit",
+                                            "type": "plain_text"
+                                        },
+                                        "type": "button",
+                                        "url": "${{ github.event.repository.html_url }}/commit/${{ github.sha }}"
+                                    }
+                                ],
+                                "type": "actions"
+                            }
+                        ],
+                        "color": "${{ github.event.workflow_run.conclusion == 'success' && '#2EB886' || github.event.workflow_run.conclusion == 'failure' && '#A30002' || '#FFCC00' }}"
+                    }
+                ]
+            }
+          token: ${{ secrets.SLACK_BOT_TOKEN_V2 }}

--- a/internal/output/ghworkflow/testdata/TestMatrixStrategy/integration-provision-triggered.yaml
+++ b/internal/output/ghworkflow/testdata/TestMatrixStrategy/integration-provision-triggered.yaml
@@ -1,0 +1,31 @@
+# THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
+#
+# Generated on 2006-01-02T15:04:05Z by test.
+
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+"on":
+  workflow_run:
+    workflows:
+      - artifacts-cron
+    types:
+      - completed
+name: integration-provision-triggered
+jobs:
+  default:
+    runs-on:
+      group: large
+    if: github.event.workflow_run.conclusion == 'success'
+    strategy:
+      matrix:
+        include:
+          - track: "0"
+          - buildEnforcing: "true"
+            track: "1"
+      max-parallel: 2
+    steps:
+      - name: build
+        if: github.event_name == 'schedule' && ${{ matrix.buildEnforcing }}
+        run: |
+          make build-${{ matrix.track }}

--- a/internal/output/ghworkflow/types.go
+++ b/internal/output/ghworkflow/types.go
@@ -86,11 +86,24 @@ type Push struct {
 	Tags []string `yaml:"tags,omitempty"`
 }
 
+// Strategy represents GitHub Actions job strategy.
+type Strategy struct {
+	Matrix      *StrategyMatrix `yaml:"matrix,omitempty"`
+	MaxParallel int             `yaml:"max-parallel,omitempty"`
+	FailFast    bool            `yaml:"fail-fast,omitempty"`
+}
+
+// StrategyMatrix represents GitHub Actions strategy matrix.
+type StrategyMatrix struct {
+	Include []map[string]string `yaml:"include"`
+}
+
 // Job represents GitHub Actions job.
 type Job struct {
 	Permissions map[string]string  `yaml:"permissions,omitempty"`
 	RunsOn      RunsOn             `yaml:"runs-on"`
 	If          string             `yaml:"if,omitempty"`
+	Strategy    *Strategy          `yaml:"strategy,omitempty"`
 	Needs       []string           `yaml:"needs,omitempty"`
 	Outputs     map[string]string  `yaml:"outputs,omitempty"`
 	Services    map[string]Service `yaml:"services,omitempty"`

--- a/internal/project/common/check_dirty.go
+++ b/internal/project/common/check_dirty.go
@@ -7,6 +7,7 @@ package common
 import (
 	"github.com/siderolabs/kres/internal/config"
 	"github.com/siderolabs/kres/internal/dag"
+	"github.com/siderolabs/kres/internal/output/ghworkflow"
 	"github.com/siderolabs/kres/internal/output/makefile"
 	"github.com/siderolabs/kres/internal/project/meta"
 )
@@ -35,7 +36,25 @@ func (c *CheckDirty) CompileMakefile(output *makefile.Output) error {
 
 	output.Target("check-dirty").
 		Phony().
+		Depends("generate").
 		Script("@if test -n \"`git status --porcelain`\"; then echo \"Source tree is dirty\"; git status; git diff; exit 1 ; fi")
+
+	return nil
+}
+
+func (c *CheckDirty) CompileGitHubWorkflow(output *ghworkflow.Output) error {
+	if c.meta.ContainerImageFrontend != config.ContainerImageFrontendDockerfile {
+		return nil
+	}
+
+	checkDirtyStep := ghworkflow.Step("Check dirty").
+		SetMakeStep("check-dirty")
+
+	if err := checkDirtyStep.SetConditions("on-pull-request"); err != nil {
+		return err
+	}
+
+	output.AddStep("default", checkDirtyStep)
 
 	return nil
 }

--- a/internal/project/common/gh_workflow.go
+++ b/internal/project/common/gh_workflow.go
@@ -6,7 +6,9 @@ package common
 
 import (
 	"fmt"
+	"maps"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/siderolabs/gen/xslices"
@@ -20,16 +22,49 @@ import (
 // Job defines options for jobs.
 type Job struct {
 	BuildxOptions *BuildxOptions `yaml:"buildxOptions,omitempty"`
+	Matrix        *Matrix        `yaml:"matrix,omitempty"`
+	OnWorkflowRun *OnWorkflowRun `yaml:"onWorkflowRun,omitempty"`
 	Name          string         `yaml:"name"`
 	RunnerGroup   string         `yaml:"runnerGroup,omitempty"`
-	Conditions    []string       `yaml:"conditions,omitempty"`
-	Crons         []string       `yaml:"crons,omitempty"`
-	Depends       []string       `yaml:"depends,omitempty"`
 	TriggerLabels []string       `yaml:"triggerLabels,omitempty"`
+	Depends       []string       `yaml:"depends,omitempty"`
 	Steps         []Step         `yaml:"steps,omitempty"`
 	Inputs        []string       `yaml:"inputs,omitempty"`
+	Crons         []string       `yaml:"crons,omitempty"`
+	Conditions    []string       `yaml:"conditions,omitempty"`
 	Dispatchable  bool           `yaml:"dispatchable"`
 	SOPS          bool           `yaml:"sops"`
+	CronOnly      bool           `yaml:"cronOnly"`
+}
+
+// MatrixEntry is one row of key-value pairs for a matrix include entry.
+// Values are interpolated into step commands, env vars, and artifact names
+// using ${{ matrix.<key> }} syntax.
+type MatrixEntry map[string]string
+
+// MatrixInclude is a matrix include entry combining key-value pairs with
+// optional per-entry trigger labels.
+type MatrixInclude struct {
+	// Values holds the key-value pairs for this matrix entry (all YAML keys
+	// that are not explicitly declared as struct fields).
+	Values MatrixEntry `yaml:",inline"`
+	// TriggerLabels lists labels that trigger only this specific flat job in
+	// ci.yaml (in addition to the job-level TriggerLabels which fire all entries).
+	TriggerLabels []string `yaml:"triggerLabels,omitempty"`
+}
+
+// Matrix configures a GitHub Actions matrix strategy on a triggered workflow,
+// and controls how ci.yaml expands the matrix into individual jobs.
+type Matrix struct {
+	Include     []MatrixInclude `yaml:"include"`
+	LabelKeys   []string        `yaml:"labelKeys,omitempty"`
+	MaxParallel int             `yaml:"maxParallel"`
+}
+
+// OnWorkflowRun defines options for workflow_run triggers.
+type OnWorkflowRun struct {
+	Workflows []string `yaml:"workflows"`
+	Types     []string `yaml:"types,omitempty"`
 }
 
 // BuildxOptions defines options for buildx.
@@ -62,6 +97,7 @@ type ArtifactStep struct {
 	Type                            string   `yaml:"type"`
 	ArtifactName                    string   `yaml:"artifactName"`
 	ArtifactPath                    string   `yaml:"artifactPath"`
+	RunID                           string   `yaml:"runID,omitempty"`
 	RetentionDays                   string   `yaml:"retentionDays,omitempty"`
 	AdditionalArtifacts             []string `yaml:"additionalArtifacts,omitempty"`
 	DisableExecutableListGeneration bool     `yaml:"disableExecutableListGeneration"`
@@ -160,6 +196,10 @@ func (gh *GHWorkflow) CompileGitHubWorkflow(o *ghworkflow.Output) error {
 			jobDef.Steps = append(jobDef.Steps, ghworkflow.SOPSSteps()...)
 		}
 
+		// Capture base steps (checkout/buildx/sops) before user steps are appended.
+		// compileFlatJobSteps uses these as its starting point.
+		baseSteps := jobDef.Steps
+
 		for _, step := range job.Steps {
 			if step.ArtifactStep != nil {
 				var steps []*ghworkflow.JobStep
@@ -207,6 +247,10 @@ func (gh *GHWorkflow) CompileGitHubWorkflow(o *ghworkflow.Output) error {
 						).
 						SetWith("name", step.ArtifactStep.ArtifactName).
 						SetWith("path", step.ArtifactStep.ArtifactPath)
+
+					if step.ArtifactStep.RunID != "" {
+						downloadArtifactsStep.SetWith("run-id", step.ArtifactStep.RunID)
+					}
 
 					if step.ContinueOnError {
 						downloadArtifactsStep.SetContinueOnError()
@@ -319,14 +363,6 @@ func (gh *GHWorkflow) CompileGitHubWorkflow(o *ghworkflow.Output) error {
 				if step.ReleaseStep.GenerateSignatures {
 					jobDef.Permissions["id-token"] = "write"
 
-					cosignStep := ghworkflow.Step("Install Cosign").
-						SetUsesWithComment(
-							"sigstore/cosign-installer@"+config.CosignInstallActionRef,
-							"version: "+config.CosignInstallActionVersion,
-						)
-
-					jobDef.Steps = append(jobDef.Steps, cosignStep)
-
 					signCommands := xslices.Map(artifacts, func(artifact string) string {
 						return fmt.Sprintf("cosign sign-blob --bundle %s.bundle --yes %s", artifact, artifact)
 					})
@@ -397,7 +433,9 @@ func (gh *GHWorkflow) CompileGitHubWorkflow(o *ghworkflow.Output) error {
 			}
 
 			for k, v := range step.Environment {
-				stepDef.SetEnv(k, v)
+				if v != "" {
+					stepDef.SetEnv(k, v)
+				}
 			}
 
 			if step.NonMakeStep {
@@ -425,6 +463,8 @@ func (gh *GHWorkflow) CompileGitHubWorkflow(o *ghworkflow.Output) error {
 			jobDef.Steps = append(jobDef.Steps, stepDef)
 		}
 
+		flatJobsAdded := false
+
 		if len(job.TriggerLabels) > 0 {
 			if len(job.Depends) < 1 {
 				return fmt.Errorf("job %s has triggerLabels but no depends", job.Name)
@@ -451,13 +491,108 @@ func (gh *GHWorkflow) CompileGitHubWorkflow(o *ghworkflow.Output) error {
 				}
 			}
 
-			conditions := xslices.Map(job.TriggerLabels, func(label string) string {
-				return fmt.Sprintf("contains(fromJSON(needs.default.outputs.labels), '%s')", label)
-			})
+			if job.Matrix != nil && len(job.Matrix.LabelKeys) > 0 {
+				// Flat job expansion: emit one individual ci.yaml job per matrix entry.
+				// Job-level triggerLabels fire all flat jobs; per-entry TriggerLabels
+				// fire only that specific entry's flat job.
+				coarseConditions := xslices.Map(job.TriggerLabels, func(label string) string {
+					return fmt.Sprintf("contains(fromJSON(needs.default.outputs.labels), '%s')", label)
+				})
 
-			for range job.TriggerLabels {
+				for _, entry := range job.Matrix.Include {
+					suffixParts := make([]string, 0, len(job.Matrix.LabelKeys))
+
+					for _, k := range job.Matrix.LabelKeys {
+						if v := entry.Values[k]; v != "" {
+							suffixParts = append(suffixParts, v)
+						}
+					}
+
+					suffix := strings.Join(suffixParts, "-")
+					flatJobName := job.Name + "-" + suffix
+					entryLabel := "integration/" + strings.TrimPrefix(flatJobName, "integration-")
+					entryCondition := fmt.Sprintf("contains(fromJSON(needs.default.outputs.labels), '%s')", entryLabel)
+
+					allConditions := append([]string{entryCondition}, coarseConditions...)
+
+					for _, label := range entry.TriggerLabels {
+						allConditions = append(allConditions, fmt.Sprintf("contains(fromJSON(needs.default.outputs.labels), '%s')", label))
+					}
+
+					flatSteps, err := compileFlatJobSteps(job, entry.Values, baseSteps)
+					if err != nil {
+						return err
+					}
+
+					flatJob := &ghworkflow.Job{
+						If:          strings.Join(allConditions, " || "),
+						RunsOn:      ghworkflow.NewRunsOnGroupLabel(job.RunnerGroup, ""),
+						Permissions: ghworkflow.DefaultJobPermissions(),
+						Needs:       job.Depends,
+						Steps:       flatSteps,
+					}
+
+					o.AddJob(flatJobName, job.Dispatchable, flatJob, job.Inputs)
+				}
+
+				flatJobsAdded = true
+			} else {
+				conditions := xslices.Map(job.TriggerLabels, func(label string) string {
+					return fmt.Sprintf("contains(fromJSON(needs.default.outputs.labels), '%s')", label)
+				})
+
 				jobDef.If = strings.Join(conditions, " || ")
 			}
+		}
+
+		if job.OnWorkflowRun != nil {
+			if len(job.OnWorkflowRun.Workflows) == 0 {
+				return fmt.Errorf("job %s has onWorkflowRun set but no workflows specified", job.Name)
+			}
+
+			workflowName := job.Name + "-triggered"
+
+			o.AddSlackNotify(workflowName)
+			o.AddSlackNotifyForFailure(workflowName)
+
+			triggeredJob := &ghworkflow.Job{
+				If:       "github.event.workflow_run.conclusion == 'success'",
+				RunsOn:   ghworkflow.NewRunsOnGroupLabel(job.RunnerGroup, ""),
+				Services: jobDef.Services,
+				Steps:    injectTriggeredRunID(jobDef.Steps),
+			}
+
+			if job.Matrix != nil {
+				triggeredJob.Strategy = &ghworkflow.Strategy{
+					MaxParallel: job.Matrix.MaxParallel,
+					Matrix: &ghworkflow.StrategyMatrix{
+						Include: xslices.Map(job.Matrix.Include, func(e MatrixInclude) map[string]string {
+							return map[string]string(e.Values)
+						}),
+					},
+				}
+			}
+
+			o.AddWorkflow(
+				workflowName,
+				&ghworkflow.Workflow{
+					Name: workflowName,
+					// https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-a-fallback-value
+					Concurrency: ghworkflow.Concurrency{
+						Group:            "${{ github.head_ref || github.run_id }}",
+						CancelInProgress: true,
+					},
+					On: ghworkflow.On{
+						WorkFlowRun: ghworkflow.WorkFlowRun{
+							Workflows: job.OnWorkflowRun.Workflows,
+							Types:     job.OnWorkflowRun.Types,
+						},
+					},
+					Jobs: map[string]*ghworkflow.Job{
+						ghworkflow.DefaultJobName: triggeredJob,
+					},
+				},
+			)
 		}
 
 		if len(job.Crons) > 0 {
@@ -493,10 +628,274 @@ func (gh *GHWorkflow) CompileGitHubWorkflow(o *ghworkflow.Output) error {
 			)
 		}
 
-		o.AddJob(job.Name, job.Dispatchable, jobDef, job.Inputs)
+		if !job.CronOnly && !flatJobsAdded {
+			o.AddJob(job.Name, job.Dispatchable, jobDef, job.Inputs)
+		}
 	}
 
 	return nil
+}
+
+// matrixSubst replaces every ${{ matrix.<key> }} placeholder in s with the
+// corresponding value from entry.  Placeholders for keys not present in entry
+// are left unchanged.
+func matrixSubst(s string, entry MatrixEntry) string {
+	for k, v := range entry {
+		s = strings.ReplaceAll(s, "${{ matrix."+k+" }}", v)
+	}
+
+	return s
+}
+
+// matrixPlaceholder matches any remaining ${{ matrix.<key> }} expression.
+var matrixPlaceholder = regexp.MustCompile(`\$\{\{\s*matrix\.\w+\s*\}\}`)
+
+// matrixSubstFull is like matrixSubst but additionally replaces any
+// ${{ matrix.<key> }} placeholders that were not resolved (i.e. absent from
+// the entry) with an empty string. Use this for flat ci.yaml job generation
+// where all matrix expressions must be resolved at compile time.
+func matrixSubstFull(s string, entry MatrixEntry) string {
+	return matrixPlaceholder.ReplaceAllString(matrixSubst(s, entry), "")
+}
+
+// resolveConditionsForEntry pre-processes step conditions for a specific matrix
+// entry (flat ci.yaml job compilation).
+//
+// For a condition of the form "matrix.<key>":
+//   - entry[key] is non-empty  → condition satisfied; no if-guard is emitted
+//   - entry[key] is empty/missing → the step must be dropped; returns (nil, false)
+//
+// All other conditions are passed through unchanged in the returned slice.
+func resolveConditionsForEntry(conditions []string, entry MatrixEntry) ([]string, bool) {
+	var resolved []string
+
+	for _, cond := range conditions {
+		if key, ok := strings.CutPrefix(cond, "matrix."); ok {
+			if entry[key] == "" {
+				return nil, false
+			}
+			// condition satisfied; no guard needed — don't append
+		} else {
+			resolved = append(resolved, cond)
+		}
+	}
+
+	return resolved, true
+}
+
+// compileFlatJobSteps compiles job.Steps for a specific matrix entry, producing
+// a concrete step list for a flat ci.yaml job.
+//
+//   - Matrix conditions are resolved at compile time (steps are dropped when the
+//     entry does not satisfy a matrix.<key> condition).
+//   - ${{ matrix.<key> }} expressions in commands, environment values, artifact
+//     names, and runID are substituted with entry[key].
+//
+// baseSteps (CommonSteps / DefaultSteps) are prepended unchanged.
+//
+//nolint:cyclop,gocognit,cyclop,gocyclo,maintidx
+func compileFlatJobSteps(job Job, entry MatrixEntry, baseSteps []*ghworkflow.JobStep) ([]*ghworkflow.JobStep, error) {
+	result := baseSteps
+
+	for _, step := range job.Steps {
+		resolvedConditions, include := resolveConditionsForEntry(step.Conditions, entry)
+		if !include {
+			continue
+		}
+
+		if step.ArtifactStep != nil {
+			var steps []*ghworkflow.JobStep
+
+			switch step.ArtifactStep.Type {
+			case "upload":
+				artifactName := matrixSubstFull(step.ArtifactStep.ArtifactName, entry)
+				artifactPath := step.ArtifactStep.ArtifactPath
+
+				saveStep := ghworkflow.Step("save artifacts").
+					SetUsesWithComment(
+						"actions/upload-artifact@"+config.UploadArtifactActionRef,
+						"version: "+config.UploadArtifactActionVersion,
+					).
+					SetWith("name", artifactName).
+					SetWith("path", artifactPath+"\n"+strings.Join(step.ArtifactStep.AdditionalArtifacts, "\n")).
+					SetWith("retention-days", "5")
+
+				if step.ArtifactStep.RetentionDays != "" {
+					saveStep.SetWith("retention-days", step.ArtifactStep.RetentionDays)
+				}
+
+				if step.ContinueOnError {
+					saveStep.SetContinueOnError()
+				}
+
+				if err := saveStep.SetConditions(resolvedConditions...); err != nil {
+					return nil, err
+				}
+
+				if !step.ArtifactStep.DisableExecutableListGeneration {
+					genStep := ghworkflow.Step("Generate executable list").
+						SetCommand(fmt.Sprintf("find %s -type f -executable > %s/executable-artifacts", artifactPath, artifactPath))
+
+					if err := genStep.SetConditions(resolvedConditions...); err != nil {
+						return nil, err
+					}
+
+					steps = append(steps, genStep)
+				}
+
+				steps = append(steps, saveStep)
+
+			case "download":
+				artifactName := matrixSubstFull(step.ArtifactStep.ArtifactName, entry)
+
+				dlStep := ghworkflow.Step("Download artifacts").
+					SetUsesWithComment(
+						"actions/download-artifact@"+config.DownloadArtifactActionRef,
+						"version: "+config.DownloadArtifactActionVersion,
+					).
+					SetWith("name", artifactName).
+					SetWith("path", step.ArtifactStep.ArtifactPath)
+
+				if step.ArtifactStep.RunID != "" {
+					dlStep.SetWith("run-id", matrixSubstFull(step.ArtifactStep.RunID, entry))
+				}
+
+				if step.ContinueOnError {
+					dlStep.SetContinueOnError()
+				}
+
+				if err := dlStep.SetConditions(resolvedConditions...); err != nil {
+					return nil, err
+				}
+
+				steps = append(steps, dlStep)
+
+				if !step.ArtifactStep.DisableExecutableListGeneration {
+					fixStep := ghworkflow.Step("Fix artifact permissions").
+						SetCommand(fmt.Sprintf("xargs -a %s/executable-artifacts -I {} chmod +x {}", step.ArtifactStep.ArtifactPath))
+
+					if err := fixStep.SetConditions(resolvedConditions...); err != nil {
+						return nil, err
+					}
+
+					steps = append(steps, fixStep)
+				}
+
+			default:
+				return nil, fmt.Errorf("unknown artifact step type: %s", step.ArtifactStep.Type)
+			}
+
+			result = append(result, steps...)
+
+			continue
+		}
+
+		if step.CheckoutStep != nil {
+			result = append(result, ghworkflow.Step(step.Name).
+				SetUsesWithComment(
+					"actions/checkout@"+config.CheckOutActionRef,
+					"version: "+config.CheckOutActionVersion,
+				).
+				SetWith("repository", step.CheckoutStep.Repository).
+				SetWith("ref", step.CheckoutStep.Ref).
+				SetWith("path", step.CheckoutStep.Path),
+			)
+
+			continue
+		}
+
+		if step.CoverageStep != nil {
+			result = append(result, ghworkflow.Step(step.Name).
+				SetUsesWithComment(
+					"codecov/codecov-action@"+config.CodeCovActionRef,
+					"version: "+config.CodeCovActionVersion,
+				).
+				SetWith("files", strings.Join(step.CoverageStep.Files, ",")).
+				SetWith("token", "${{ secrets.CODECOV_TOKEN }}").
+				SetTimeoutMinutes(step.TimeoutMinutes),
+			)
+
+			continue
+		}
+
+		if step.TerraformStep {
+			result = append(result, ghworkflow.Step(step.Name).
+				SetUsesWithComment(
+					"hashicorp/setup-terraform@"+config.SetupTerraformActionRef,
+					"version: "+config.SetupTerraformActionVersion,
+				).
+				SetWith("terraform_wrapper", "false"),
+			)
+
+			continue
+		}
+
+		if step.RegistryLoginStep != nil {
+			loginStep := ghworkflow.Step(step.Name).
+				SetUsesWithComment(
+					"docker/login-action@"+config.LoginActionRef,
+					"version: "+config.LoginActionVersion,
+				).
+				SetWith("registry", step.RegistryLoginStep.Registry)
+
+			if step.RegistryLoginStep.Registry == "ghcr.io" {
+				loginStep.SetWith("username", "${{ github.repository_owner }}")
+				loginStep.SetWith("password", "${{ secrets.GITHUB_TOKEN }}")
+			}
+
+			if err := loginStep.SetConditions(resolvedConditions...); err != nil {
+				return nil, err
+			}
+
+			result = append(result, loginStep)
+
+			continue
+		}
+
+		// Plain command step
+		command := matrixSubstFull(step.Command, entry)
+		if command == "" {
+			command = step.Name
+		}
+
+		stepDef := ghworkflow.Step(step.Name)
+		stepDef.SetTimeoutMinutes(step.TimeoutMinutes)
+
+		if step.ContinueOnError {
+			stepDef.SetContinueOnError()
+		}
+
+		if err := stepDef.SetConditions(resolvedConditions...); err != nil {
+			return nil, err
+		}
+
+		for k, v := range step.Environment {
+			if val := matrixSubstFull(v, entry); val != "" {
+				stepDef.SetEnv(k, val)
+			}
+		}
+
+		if step.NonMakeStep {
+			if len(step.Arguments) > 0 {
+				command += " " + strings.Join(step.Arguments, "")
+			}
+
+			stepDef.SetCommand(command)
+			result = append(result, stepDef)
+
+			continue
+		}
+
+		stepDef.SetMakeStep(command, step.Arguments...)
+
+		if step.WithSudo {
+			stepDef.SetSudo()
+		}
+
+		result = append(result, stepDef)
+	}
+
+	return result, nil
 }
 
 // DefaultCIFailureSlackNotifyChannel is the default channel for CI failure Slack notifications.
@@ -510,4 +909,32 @@ func (gh *GHWorkflow) AfterLoad() error {
 	}
 
 	return nil
+}
+
+// injectTriggeredRunID returns a copy of steps where any actions/download-artifact
+// step that doesn't already have run-id set gets it injected with the workflow_run
+// event's run ID. This avoids mutating the shared jobDef.Steps slice.
+func injectTriggeredRunID(steps []*ghworkflow.JobStep) []*ghworkflow.JobStep {
+	downloadRef := "actions/download-artifact@" + config.DownloadArtifactActionRef
+	result := make([]*ghworkflow.JobStep, len(steps))
+
+	for i, step := range steps {
+		if step.Uses.Image == downloadRef {
+			if _, ok := step.With["run-id"]; !ok {
+				clone := *step
+				clone.With = make(map[string]string, len(step.With)+1)
+
+				maps.Copy(clone.With, step.With)
+
+				clone.With["run-id"] = "${{ github.event.workflow_run.id }}"
+				result[i] = &clone
+
+				continue
+			}
+		}
+
+		result[i] = step
+	}
+
+	return result
 }

--- a/internal/project/common/gh_workflow_test.go
+++ b/internal/project/common/gh_workflow_test.go
@@ -1,0 +1,280 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package common_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/kres/internal/output"
+	"github.com/siderolabs/kres/internal/output/ghworkflow"
+	"github.com/siderolabs/kres/internal/project/common"
+	"github.com/siderolabs/kres/internal/project/meta"
+)
+
+// set to true to regenerate testdata golden files.
+var update = false //nolint:gochecknoglobals
+
+func assertGolden(t *testing.T, filename string, got []byte) {
+	t.Helper()
+
+	path := filepath.Join("testdata", t.Name(), filepath.Base(filename))
+
+	if update {
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, got, 0o600))
+
+		return
+	}
+
+	want, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, string(want), string(got))
+}
+
+func newTestOutput() *ghworkflow.Output {
+	o := ghworkflow.NewOutput("main", true, false, "")
+	o.SetRunnerGroup(ghworkflow.GenericRunner)
+
+	return o
+}
+
+func compileWorkflow(t *testing.T, jobs []common.Job) *ghworkflow.Output {
+	t.Helper()
+
+	output.PreambleTimestamp, _ = time.Parse(time.RFC3339, strings.ReplaceAll(time.RFC3339, "07:00", "")) //nolint:errcheck
+	output.PreambleCreator = "test"
+
+	m := &meta.Options{CompileGithubWorkflowsOnly: true}
+	gw := common.NewGHWorkflow(m)
+	gw.Jobs = jobs
+
+	o := newTestOutput()
+
+	require.NoError(t, gw.CompileGitHubWorkflow(o))
+
+	return o
+}
+
+// TestMatrixLabelKeysExpansion verifies that when a matrix job has LabelKeys set,
+// CompileGitHubWorkflow emits N flat jobs in ci.yaml instead of a single matrix job.
+func TestMatrixLabelKeysExpansion(t *testing.T) {
+	jobs := []common.Job{
+		{
+			Name:        "integration-aws-nvidia-nonfree",
+			RunnerGroup: "large",
+			Depends:     []string{"default"},
+			TriggerLabels: []string{
+				"integration/aws-nvidia-nonfree",
+				"integration/aws-nvidia",
+			},
+			Matrix: &common.Matrix{
+				MaxParallel: 2,
+				LabelKeys:   []string{"variant", "arch"},
+				Include: []common.MatrixInclude{
+					{Values: common.MatrixEntry{"variant": "lts", "arch": "amd64"}},
+					{Values: common.MatrixEntry{"variant": "production", "arch": "arm64"}},
+				},
+			},
+			Steps: []common.Step{
+				{
+					Name:    "run-tests",
+					Command: "integration-${{ matrix.variant }}-${{ matrix.arch }}",
+					Environment: map[string]string{
+						"VARIANT": "${{ matrix.variant }}",
+						"ARCH":    "${{ matrix.arch }}",
+					},
+				},
+				{
+					Name: "save-logs",
+					ArtifactStep: &common.ArtifactStep{
+						Type:                            "upload",
+						ArtifactName:                    "logs-${{ matrix.variant }}-${{ matrix.arch }}",
+						ArtifactPath:                    "/tmp/logs",
+						DisableExecutableListGeneration: true,
+					},
+				},
+			},
+		},
+	}
+
+	o := compileWorkflow(t, jobs)
+
+	var buf bytes.Buffer
+
+	require.NoError(t, o.GenerateFile(ghworkflow.CiWorkflow, &buf))
+	assertGolden(t, "ci.yaml", buf.Bytes())
+}
+
+// TestMatrixConditionResolution verifies that matrix.* conditions are resolved at
+// compile time for flat jobs: steps whose matrix condition is not satisfied by an
+// entry are dropped; steps whose condition is satisfied have no if-guard for it.
+func TestMatrixConditionResolution(t *testing.T) {
+	jobs := []common.Job{
+		{
+			Name:        "integration-provision",
+			RunnerGroup: "large",
+			Depends:     []string{"default"},
+			TriggerLabels: []string{
+				"integration/provision",
+			},
+			Matrix: &common.Matrix{
+				MaxParallel: 2,
+				LabelKeys:   []string{"track"},
+				Include: []common.MatrixInclude{
+					{Values: common.MatrixEntry{"track": "0"}},
+					{Values: common.MatrixEntry{"track": "1", "buildEnforcing": "true"}},
+				},
+			},
+			Steps: []common.Step{
+				{
+					Name:    "always-step",
+					Command: "always-${{ matrix.track }}",
+				},
+				{
+					Name:    "enforcing-only",
+					Command: "enforcing",
+					Conditions: []string{
+						"only-on-schedule",
+						"matrix.buildEnforcing",
+					},
+				},
+			},
+		},
+	}
+
+	o := compileWorkflow(t, jobs)
+
+	var buf bytes.Buffer
+
+	require.NoError(t, o.GenerateFile(ghworkflow.CiWorkflow, &buf))
+	assertGolden(t, "ci.yaml", buf.Bytes())
+}
+
+// TestTriggeredRunIDAutoInject verifies that a triggered workflow without an
+// explicit RunID on the download step gets run-id auto-injected, while the
+// ci.yaml job for the same job definition does NOT get run-id.
+func TestTriggeredRunIDAutoInject(t *testing.T) {
+	jobs := []common.Job{
+		{
+			Name:        "integration-qemu-race",
+			RunnerGroup: "large",
+			Depends:     []string{"default"},
+			TriggerLabels: []string{
+				"integration/qemu-race",
+			},
+			OnWorkflowRun: &common.OnWorkflowRun{
+				Workflows: []string{"artifacts-cron"},
+				Types:     []string{"completed"},
+			},
+			Steps: []common.Step{
+				{
+					Name: "download-artifacts",
+					ArtifactStep: &common.ArtifactStep{
+						Type:                            "download",
+						ArtifactName:                    "talos-artifacts",
+						ArtifactPath:                    "_out",
+						DisableExecutableListGeneration: true,
+					},
+				},
+			},
+		},
+	}
+
+	o := compileWorkflow(t, jobs)
+
+	var triggeredBuf bytes.Buffer
+
+	require.NoError(t, o.GenerateFile(".github/workflows/integration-qemu-race-triggered.yaml", &triggeredBuf))
+	assertGolden(t, "integration-qemu-race-triggered.yaml", triggeredBuf.Bytes())
+
+	var ciBuf bytes.Buffer
+
+	require.NoError(t, o.GenerateFile(ghworkflow.CiWorkflow, &ciBuf))
+	assertGolden(t, "ci.yaml", ciBuf.Bytes())
+}
+
+// TestArtifactStepRunID verifies that RunID on ArtifactStep is rendered as
+// run-id in the download step, and that the triggered-workflow auto-inject
+// does not overwrite it.
+func TestArtifactStepRunID(t *testing.T) {
+	jobs := []common.Job{
+		{
+			Name:        "integration-provision",
+			RunnerGroup: "large",
+			OnWorkflowRun: &common.OnWorkflowRun{
+				Workflows: []string{"artifacts-cron"},
+				Types:     []string{"completed"},
+			},
+			Steps: []common.Step{
+				{
+					Name: "download-artifacts",
+					ArtifactStep: &common.ArtifactStep{
+						Type:                            "download",
+						ArtifactName:                    "talos-artifacts",
+						ArtifactPath:                    "_out",
+						RunID:                           "${{ github.event.workflow_run.id || github.run_id }}",
+						DisableExecutableListGeneration: true,
+					},
+				},
+			},
+		},
+	}
+
+	o := compileWorkflow(t, jobs)
+
+	var buf bytes.Buffer
+
+	require.NoError(t, o.GenerateFile(".github/workflows/integration-provision-triggered.yaml", &buf))
+	assertGolden(t, "integration-provision-triggered.yaml", buf.Bytes())
+}
+
+// TestMatrixPerEntryTriggerLabels verifies that per-entry TriggerLabels fire only
+// the matching flat job, while job-level TriggerLabels fire all flat jobs.
+// This tests the combined oss/nonfree scenario where integration/aws-nvidia-oss must
+// NOT trigger nonfree flat jobs.
+func TestMatrixPerEntryTriggerLabels(t *testing.T) {
+	jobs := []common.Job{
+		{
+			Name:        "integration-aws-nvidia",
+			RunnerGroup: "large",
+			Depends:     []string{"default"},
+			TriggerLabels: []string{
+				"integration/aws-nvidia", // job-level: fires all flat jobs
+			},
+			Matrix: &common.Matrix{
+				MaxParallel: 2,
+				LabelKeys:   []string{"driver", "variant"},
+				Include: []common.MatrixInclude{
+					{
+						Values:        common.MatrixEntry{"driver": "oss", "variant": "lts"},
+						TriggerLabels: []string{"integration/aws-nvidia-oss"},
+					},
+					{
+						Values:        common.MatrixEntry{"driver": "nonfree", "variant": "lts"},
+						TriggerLabels: []string{"integration/aws-nvidia-nonfree"},
+					},
+				},
+			},
+			Steps: []common.Step{
+				{Name: "run-tests", Command: "e2e-${{ matrix.driver }}-${{ matrix.variant }}"},
+			},
+		},
+	}
+
+	o := compileWorkflow(t, jobs)
+
+	var buf bytes.Buffer
+
+	require.NoError(t, o.GenerateFile(ghworkflow.CiWorkflow, &buf))
+	assertGolden(t, "ci.yaml", buf.Bytes())
+}

--- a/internal/project/common/release.go
+++ b/internal/project/common/release.go
@@ -98,16 +98,6 @@ func (release *Release) CompileGitHubWorkflow(output *ghworkflow.Output) error {
 		if release.GenerateSignatures {
 			output.AddJobPermissions(ghworkflow.DefaultJobName, "id-token", "write")
 
-			cosignStep := ghworkflow.Step("Install Cosign").
-				SetUsesWithComment(
-					"sigstore/cosign-installer@"+config.CosignInstallActionRef,
-					"version: "+config.CosignInstallActionVersion,
-				)
-
-			if err := cosignStep.SetConditions("only-on-tag"); err != nil {
-				return err
-			}
-
 			signCommands := xslices.Map(artifacts, func(artifact string) string {
 				return fmt.Sprintf("find %s -type f -name %s -exec cosign sign-blob --yes --bundle {}.bundle {} \\;", release.meta.ArtifactsPath, artifact)
 			})
@@ -119,7 +109,7 @@ func (release *Release) CompileGitHubWorkflow(output *ghworkflow.Output) error {
 				return err
 			}
 
-			steps = append(steps, cosignStep, signStep)
+			steps = append(steps, signStep)
 
 			artifactsToUpload += "\n" + filepath.Join(release.meta.ArtifactsPath, "*.bundle")
 		}

--- a/internal/project/common/testdata/TestArtifactStepRunID/integration-provision-triggered.yaml
+++ b/internal/project/common/testdata/TestArtifactStepRunID/integration-provision-triggered.yaml
@@ -1,0 +1,56 @@
+# THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
+#
+# Generated on 2006-01-02T15:04:05Z by test.
+
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+"on":
+  workflow_run:
+    workflows:
+      - artifacts-cron
+    types:
+      - completed
+name: integration-provision-triggered
+jobs:
+  default:
+    runs-on:
+      group: large
+    if: github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: gather-system-info
+        id: system-info
+        uses: kenchan0130/actions-system-info@59699597e84e80085a750998045983daa49274c4 # version: v1.4.0
+        continue-on-error: true
+      - name: print-system-info
+        run: |
+          MEMORY_GB=$((${{ steps.system-info.outputs.totalmem }}/1024/1024/1024))
+
+          OUTPUTS=(
+            "CPU Core: ${{ steps.system-info.outputs.cpu-core }}"
+            "CPU Model: ${{ steps.system-info.outputs.cpu-model }}"
+            "Hostname: ${{ steps.system-info.outputs.hostname }}"
+            "NodeName: ${NODE_NAME}"
+            "Kernel release: ${{ steps.system-info.outputs.kernel-release }}"
+            "Kernel version: ${{ steps.system-info.outputs.kernel-version }}"
+            "Name: ${{ steps.system-info.outputs.name }}"
+            "Platform: ${{ steps.system-info.outputs.platform }}"
+            "Release: ${{ steps.system-info.outputs.release }}"
+            "Total memory: ${MEMORY_GB} GB"
+          )
+
+          for OUTPUT in "${OUTPUTS[@]}";do
+            echo "${OUTPUT}"
+          done
+        continue-on-error: true
+      - name: checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # version: v6.0.2
+      - name: Unshallow
+        run: |
+          git fetch --prune --unshallow
+      - name: Download artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # version: v8.0.1
+        with:
+          name: talos-artifacts
+          path: _out
+          run-id: ${{ github.event.workflow_run.id || github.run_id }}

--- a/internal/project/common/testdata/TestMatrixConditionResolution/ci.yaml
+++ b/internal/project/common/testdata/TestMatrixConditionResolution/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-17T08:42:15Z by kres b6d29bf-dirty.
+# Generated on 2006-01-02T15:04:05Z by test.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -22,13 +22,14 @@ jobs:
     permissions:
       actions: read
       contents: write
-      id-token: write
       issues: read
       packages: write
       pull-requests: read
     runs-on:
       group: generic
     if: (!startsWith(github.head_ref, 'renovate/') && !startsWith(github.head_ref, 'dependabot/'))
+    outputs:
+      labels: ${{ steps.retrieve-pr-labels.outputs.result }}
     steps:
       - name: gather-system-info
         id: system-info
@@ -67,68 +68,31 @@ jobs:
           driver: remote
           endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
         timeout-minutes: 10
-      - name: Check dirty
-        if: github.event_name == 'pull_request'
-        run: |
-          make check-dirty
-      - name: base
-        run: |
-          make base
-      - name: kres
-        run: |
-          make kres
-      - name: Login to registry
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # version: v4.1.0
+      - name: Retrieve PR labels
+        id: retrieve-pr-labels
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # version: v8.0.0
         with:
-          password: ${{ secrets.GITHUB_TOKEN }}
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-      - name: image-kres
-        run: |
-          make image-kres
-      - name: push-kres
-        if: github.event_name != 'pull_request'
-        env:
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make image-kres
-      - name: push-kres-latest
-        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
-        env:
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make image-kres IMAGE_TAG=latest
-      - name: Sign artifacts
-        if: startsWith(github.ref, 'refs/tags/')
-        run: |
-          find _out -type f -name _out/kres-* -exec cosign sign-blob --yes --bundle {}.bundle {} \;
-      - name: Generate Checksums
-        if: startsWith(github.ref, 'refs/tags/')
-        run: |
-          cd _out
-          sha256sum kres-* > sha256sum.txt
-          sha512sum kres-* > sha512sum.txt
-      - name: release-notes
-        if: startsWith(github.ref, 'refs/tags/')
-        run: |
-          make release-notes
-      - name: Release
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # version: v2.6.1
-        with:
-          body_path: _out/RELEASE_NOTES.md
-          draft: "true"
-          files: |-
-            _out/kres-*
-            _out/sha*.txt
-            _out/*.bundle
-  lint:
+          retries: "3"
+          script: |
+            if (context.eventName != "pull_request") { return "[]" }
+
+            const resp = await github.rest.issues.get({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+            })
+
+            return resp.data.labels.map(label => label.name)
+  integration-provision-0:
+    permissions:
+      actions: read
+      contents: write
+      issues: read
+      packages: write
+      pull-requests: read
     runs-on:
-      group: generic
-    if: github.event_name == 'pull_request'
+      group: large
+    if: contains(fromJSON(needs.default.outputs.labels), 'integration/provision-0') || contains(fromJSON(needs.default.outputs.labels), 'integration/provision')
     needs:
       - default
     steps:
@@ -162,20 +126,19 @@ jobs:
       - name: Unshallow
         run: |
           git fetch --prune --unshallow
-      - name: Set up Docker Buildx
-        id: setup-buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # version: v4.0.0
-        with:
-          driver: remote
-          endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
-        timeout-minutes: 10
-      - name: lint
+      - name: always-step
         run: |
-          make lint
-  unit-tests:
+          make always-0
+  integration-provision-1:
+    permissions:
+      actions: read
+      contents: write
+      issues: read
+      packages: write
+      pull-requests: read
     runs-on:
-      group: generic
-    if: github.event_name == 'pull_request'
+      group: large
+    if: contains(fromJSON(needs.default.outputs.labels), 'integration/provision-1') || contains(fromJSON(needs.default.outputs.labels), 'integration/provision')
     needs:
       - default
     steps:
@@ -209,23 +172,10 @@ jobs:
       - name: Unshallow
         run: |
           git fetch --prune --unshallow
-      - name: Set up Docker Buildx
-        id: setup-buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # version: v4.0.0
-        with:
-          driver: remote
-          endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
-        timeout-minutes: 10
-      - name: unit-tests
+      - name: always-step
         run: |
-          make unit-tests
-      - name: unit-tests-race
+          make always-1
+      - name: enforcing-only
+        if: github.event_name == 'schedule'
         run: |
-          make unit-tests-race
-      - name: coverage
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # version: v6.0.0
-        with:
-          files: _out/coverage-unit-tests.txt
-          flags: unit-tests
-          token: ${{ secrets.CODECOV_TOKEN }}
-        timeout-minutes: 3
+          make enforcing

--- a/internal/project/common/testdata/TestMatrixLabelKeysExpansion/ci.yaml
+++ b/internal/project/common/testdata/TestMatrixLabelKeysExpansion/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-17T08:42:15Z by kres b6d29bf-dirty.
+# Generated on 2006-01-02T15:04:05Z by test.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -22,13 +22,14 @@ jobs:
     permissions:
       actions: read
       contents: write
-      id-token: write
       issues: read
       packages: write
       pull-requests: read
     runs-on:
       group: generic
     if: (!startsWith(github.head_ref, 'renovate/') && !startsWith(github.head_ref, 'dependabot/'))
+    outputs:
+      labels: ${{ steps.retrieve-pr-labels.outputs.result }}
     steps:
       - name: gather-system-info
         id: system-info
@@ -67,68 +68,31 @@ jobs:
           driver: remote
           endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
         timeout-minutes: 10
-      - name: Check dirty
-        if: github.event_name == 'pull_request'
-        run: |
-          make check-dirty
-      - name: base
-        run: |
-          make base
-      - name: kres
-        run: |
-          make kres
-      - name: Login to registry
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # version: v4.1.0
+      - name: Retrieve PR labels
+        id: retrieve-pr-labels
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # version: v8.0.0
         with:
-          password: ${{ secrets.GITHUB_TOKEN }}
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-      - name: image-kres
-        run: |
-          make image-kres
-      - name: push-kres
-        if: github.event_name != 'pull_request'
-        env:
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make image-kres
-      - name: push-kres-latest
-        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
-        env:
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make image-kres IMAGE_TAG=latest
-      - name: Sign artifacts
-        if: startsWith(github.ref, 'refs/tags/')
-        run: |
-          find _out -type f -name _out/kres-* -exec cosign sign-blob --yes --bundle {}.bundle {} \;
-      - name: Generate Checksums
-        if: startsWith(github.ref, 'refs/tags/')
-        run: |
-          cd _out
-          sha256sum kres-* > sha256sum.txt
-          sha512sum kres-* > sha512sum.txt
-      - name: release-notes
-        if: startsWith(github.ref, 'refs/tags/')
-        run: |
-          make release-notes
-      - name: Release
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # version: v2.6.1
-        with:
-          body_path: _out/RELEASE_NOTES.md
-          draft: "true"
-          files: |-
-            _out/kres-*
-            _out/sha*.txt
-            _out/*.bundle
-  lint:
+          retries: "3"
+          script: |
+            if (context.eventName != "pull_request") { return "[]" }
+
+            const resp = await github.rest.issues.get({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+            })
+
+            return resp.data.labels.map(label => label.name)
+  integration-aws-nvidia-nonfree-lts-amd64:
+    permissions:
+      actions: read
+      contents: write
+      issues: read
+      packages: write
+      pull-requests: read
     runs-on:
-      group: generic
-    if: github.event_name == 'pull_request'
+      group: large
+    if: contains(fromJSON(needs.default.outputs.labels), 'integration/aws-nvidia-nonfree-lts-amd64') || contains(fromJSON(needs.default.outputs.labels), 'integration/aws-nvidia-nonfree') || contains(fromJSON(needs.default.outputs.labels), 'integration/aws-nvidia')
     needs:
       - default
     steps:
@@ -162,20 +126,29 @@ jobs:
       - name: Unshallow
         run: |
           git fetch --prune --unshallow
-      - name: Set up Docker Buildx
-        id: setup-buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # version: v4.0.0
-        with:
-          driver: remote
-          endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
-        timeout-minutes: 10
-      - name: lint
+      - name: run-tests
+        env:
+          ARCH: amd64
+          VARIANT: lts
         run: |
-          make lint
-  unit-tests:
+          make integration-lts-amd64
+      - name: save artifacts
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # version: v7.0.0
+        with:
+          name: logs-lts-amd64
+          path: |
+            /tmp/logs
+          retention-days: "5"
+  integration-aws-nvidia-nonfree-production-arm64:
+    permissions:
+      actions: read
+      contents: write
+      issues: read
+      packages: write
+      pull-requests: read
     runs-on:
-      group: generic
-    if: github.event_name == 'pull_request'
+      group: large
+    if: contains(fromJSON(needs.default.outputs.labels), 'integration/aws-nvidia-nonfree-production-arm64') || contains(fromJSON(needs.default.outputs.labels), 'integration/aws-nvidia-nonfree') || contains(fromJSON(needs.default.outputs.labels), 'integration/aws-nvidia')
     needs:
       - default
     steps:
@@ -209,23 +182,16 @@ jobs:
       - name: Unshallow
         run: |
           git fetch --prune --unshallow
-      - name: Set up Docker Buildx
-        id: setup-buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # version: v4.0.0
-        with:
-          driver: remote
-          endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
-        timeout-minutes: 10
-      - name: unit-tests
+      - name: run-tests
+        env:
+          ARCH: arm64
+          VARIANT: production
         run: |
-          make unit-tests
-      - name: unit-tests-race
-        run: |
-          make unit-tests-race
-      - name: coverage
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # version: v6.0.0
+          make integration-production-arm64
+      - name: save artifacts
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # version: v7.0.0
         with:
-          files: _out/coverage-unit-tests.txt
-          flags: unit-tests
-          token: ${{ secrets.CODECOV_TOKEN }}
-        timeout-minutes: 3
+          name: logs-production-arm64
+          path: |
+            /tmp/logs
+          retention-days: "5"

--- a/internal/project/common/testdata/TestMatrixPerEntryTriggerLabels/ci.yaml
+++ b/internal/project/common/testdata/TestMatrixPerEntryTriggerLabels/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-17T08:42:15Z by kres b6d29bf-dirty.
+# Generated on 2006-01-02T15:04:05Z by test.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -22,13 +22,14 @@ jobs:
     permissions:
       actions: read
       contents: write
-      id-token: write
       issues: read
       packages: write
       pull-requests: read
     runs-on:
       group: generic
     if: (!startsWith(github.head_ref, 'renovate/') && !startsWith(github.head_ref, 'dependabot/'))
+    outputs:
+      labels: ${{ steps.retrieve-pr-labels.outputs.result }}
     steps:
       - name: gather-system-info
         id: system-info
@@ -67,68 +68,31 @@ jobs:
           driver: remote
           endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
         timeout-minutes: 10
-      - name: Check dirty
-        if: github.event_name == 'pull_request'
-        run: |
-          make check-dirty
-      - name: base
-        run: |
-          make base
-      - name: kres
-        run: |
-          make kres
-      - name: Login to registry
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # version: v4.1.0
+      - name: Retrieve PR labels
+        id: retrieve-pr-labels
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # version: v8.0.0
         with:
-          password: ${{ secrets.GITHUB_TOKEN }}
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-      - name: image-kres
-        run: |
-          make image-kres
-      - name: push-kres
-        if: github.event_name != 'pull_request'
-        env:
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make image-kres
-      - name: push-kres-latest
-        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
-        env:
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make image-kres IMAGE_TAG=latest
-      - name: Sign artifacts
-        if: startsWith(github.ref, 'refs/tags/')
-        run: |
-          find _out -type f -name _out/kres-* -exec cosign sign-blob --yes --bundle {}.bundle {} \;
-      - name: Generate Checksums
-        if: startsWith(github.ref, 'refs/tags/')
-        run: |
-          cd _out
-          sha256sum kres-* > sha256sum.txt
-          sha512sum kres-* > sha512sum.txt
-      - name: release-notes
-        if: startsWith(github.ref, 'refs/tags/')
-        run: |
-          make release-notes
-      - name: Release
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # version: v2.6.1
-        with:
-          body_path: _out/RELEASE_NOTES.md
-          draft: "true"
-          files: |-
-            _out/kres-*
-            _out/sha*.txt
-            _out/*.bundle
-  lint:
+          retries: "3"
+          script: |
+            if (context.eventName != "pull_request") { return "[]" }
+
+            const resp = await github.rest.issues.get({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+            })
+
+            return resp.data.labels.map(label => label.name)
+  integration-aws-nvidia-nonfree-lts:
+    permissions:
+      actions: read
+      contents: write
+      issues: read
+      packages: write
+      pull-requests: read
     runs-on:
-      group: generic
-    if: github.event_name == 'pull_request'
+      group: large
+    if: contains(fromJSON(needs.default.outputs.labels), 'integration/aws-nvidia-nonfree-lts') || contains(fromJSON(needs.default.outputs.labels), 'integration/aws-nvidia') || contains(fromJSON(needs.default.outputs.labels), 'integration/aws-nvidia-nonfree')
     needs:
       - default
     steps:
@@ -162,20 +126,19 @@ jobs:
       - name: Unshallow
         run: |
           git fetch --prune --unshallow
-      - name: Set up Docker Buildx
-        id: setup-buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # version: v4.0.0
-        with:
-          driver: remote
-          endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
-        timeout-minutes: 10
-      - name: lint
+      - name: run-tests
         run: |
-          make lint
-  unit-tests:
+          make e2e-nonfree-lts
+  integration-aws-nvidia-oss-lts:
+    permissions:
+      actions: read
+      contents: write
+      issues: read
+      packages: write
+      pull-requests: read
     runs-on:
-      group: generic
-    if: github.event_name == 'pull_request'
+      group: large
+    if: contains(fromJSON(needs.default.outputs.labels), 'integration/aws-nvidia-oss-lts') || contains(fromJSON(needs.default.outputs.labels), 'integration/aws-nvidia') || contains(fromJSON(needs.default.outputs.labels), 'integration/aws-nvidia-oss')
     needs:
       - default
     steps:
@@ -209,23 +172,6 @@ jobs:
       - name: Unshallow
         run: |
           git fetch --prune --unshallow
-      - name: Set up Docker Buildx
-        id: setup-buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # version: v4.0.0
-        with:
-          driver: remote
-          endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
-        timeout-minutes: 10
-      - name: unit-tests
+      - name: run-tests
         run: |
-          make unit-tests
-      - name: unit-tests-race
-        run: |
-          make unit-tests-race
-      - name: coverage
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # version: v6.0.0
-        with:
-          files: _out/coverage-unit-tests.txt
-          flags: unit-tests
-          token: ${{ secrets.CODECOV_TOKEN }}
-        timeout-minutes: 3
+          make e2e-oss-lts

--- a/internal/project/common/testdata/TestTriggeredRunIDAutoInject/ci.yaml
+++ b/internal/project/common/testdata/TestTriggeredRunIDAutoInject/ci.yaml
@@ -1,0 +1,133 @@
+# THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
+#
+# Generated on 2006-01-02T15:04:05Z by test.
+
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+"on":
+  push:
+    branches:
+      - main
+      - release-*
+    tags:
+      - v*
+  pull_request:
+    branches:
+      - main
+      - release-*
+name: default
+jobs:
+  default:
+    permissions:
+      actions: read
+      contents: write
+      issues: read
+      packages: write
+      pull-requests: read
+    runs-on:
+      group: generic
+    if: (!startsWith(github.head_ref, 'renovate/') && !startsWith(github.head_ref, 'dependabot/'))
+    outputs:
+      labels: ${{ steps.retrieve-pr-labels.outputs.result }}
+    steps:
+      - name: gather-system-info
+        id: system-info
+        uses: kenchan0130/actions-system-info@59699597e84e80085a750998045983daa49274c4 # version: v1.4.0
+        continue-on-error: true
+      - name: print-system-info
+        run: |
+          MEMORY_GB=$((${{ steps.system-info.outputs.totalmem }}/1024/1024/1024))
+
+          OUTPUTS=(
+            "CPU Core: ${{ steps.system-info.outputs.cpu-core }}"
+            "CPU Model: ${{ steps.system-info.outputs.cpu-model }}"
+            "Hostname: ${{ steps.system-info.outputs.hostname }}"
+            "NodeName: ${NODE_NAME}"
+            "Kernel release: ${{ steps.system-info.outputs.kernel-release }}"
+            "Kernel version: ${{ steps.system-info.outputs.kernel-version }}"
+            "Name: ${{ steps.system-info.outputs.name }}"
+            "Platform: ${{ steps.system-info.outputs.platform }}"
+            "Release: ${{ steps.system-info.outputs.release }}"
+            "Total memory: ${MEMORY_GB} GB"
+          )
+
+          for OUTPUT in "${OUTPUTS[@]}";do
+            echo "${OUTPUT}"
+          done
+        continue-on-error: true
+      - name: checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # version: v6.0.2
+      - name: Unshallow
+        run: |
+          git fetch --prune --unshallow
+      - name: Set up Docker Buildx
+        id: setup-buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # version: v4.0.0
+        with:
+          driver: remote
+          endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
+        timeout-minutes: 10
+      - name: Retrieve PR labels
+        id: retrieve-pr-labels
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # version: v8.0.0
+        with:
+          retries: "3"
+          script: |
+            if (context.eventName != "pull_request") { return "[]" }
+
+            const resp = await github.rest.issues.get({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+            })
+
+            return resp.data.labels.map(label => label.name)
+  integration-qemu-race:
+    permissions:
+      actions: read
+      contents: write
+      issues: read
+      packages: write
+      pull-requests: read
+    runs-on:
+      group: large
+    if: contains(fromJSON(needs.default.outputs.labels), 'integration/qemu-race')
+    needs:
+      - default
+    steps:
+      - name: gather-system-info
+        id: system-info
+        uses: kenchan0130/actions-system-info@59699597e84e80085a750998045983daa49274c4 # version: v1.4.0
+        continue-on-error: true
+      - name: print-system-info
+        run: |
+          MEMORY_GB=$((${{ steps.system-info.outputs.totalmem }}/1024/1024/1024))
+
+          OUTPUTS=(
+            "CPU Core: ${{ steps.system-info.outputs.cpu-core }}"
+            "CPU Model: ${{ steps.system-info.outputs.cpu-model }}"
+            "Hostname: ${{ steps.system-info.outputs.hostname }}"
+            "NodeName: ${NODE_NAME}"
+            "Kernel release: ${{ steps.system-info.outputs.kernel-release }}"
+            "Kernel version: ${{ steps.system-info.outputs.kernel-version }}"
+            "Name: ${{ steps.system-info.outputs.name }}"
+            "Platform: ${{ steps.system-info.outputs.platform }}"
+            "Release: ${{ steps.system-info.outputs.release }}"
+            "Total memory: ${MEMORY_GB} GB"
+          )
+
+          for OUTPUT in "${OUTPUTS[@]}";do
+            echo "${OUTPUT}"
+          done
+        continue-on-error: true
+      - name: checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # version: v6.0.2
+      - name: Unshallow
+        run: |
+          git fetch --prune --unshallow
+      - name: Download artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # version: v8.0.1
+        with:
+          name: talos-artifacts
+          path: _out

--- a/internal/project/common/testdata/TestTriggeredRunIDAutoInject/integration-qemu-race-triggered.yaml
+++ b/internal/project/common/testdata/TestTriggeredRunIDAutoInject/integration-qemu-race-triggered.yaml
@@ -1,0 +1,56 @@
+# THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
+#
+# Generated on 2006-01-02T15:04:05Z by test.
+
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+"on":
+  workflow_run:
+    workflows:
+      - artifacts-cron
+    types:
+      - completed
+name: integration-qemu-race-triggered
+jobs:
+  default:
+    runs-on:
+      group: large
+    if: github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: gather-system-info
+        id: system-info
+        uses: kenchan0130/actions-system-info@59699597e84e80085a750998045983daa49274c4 # version: v1.4.0
+        continue-on-error: true
+      - name: print-system-info
+        run: |
+          MEMORY_GB=$((${{ steps.system-info.outputs.totalmem }}/1024/1024/1024))
+
+          OUTPUTS=(
+            "CPU Core: ${{ steps.system-info.outputs.cpu-core }}"
+            "CPU Model: ${{ steps.system-info.outputs.cpu-model }}"
+            "Hostname: ${{ steps.system-info.outputs.hostname }}"
+            "NodeName: ${NODE_NAME}"
+            "Kernel release: ${{ steps.system-info.outputs.kernel-release }}"
+            "Kernel version: ${{ steps.system-info.outputs.kernel-version }}"
+            "Name: ${{ steps.system-info.outputs.name }}"
+            "Platform: ${{ steps.system-info.outputs.platform }}"
+            "Release: ${{ steps.system-info.outputs.release }}"
+            "Total memory: ${MEMORY_GB} GB"
+          )
+
+          for OUTPUT in "${OUTPUTS[@]}";do
+            echo "${OUTPUT}"
+          done
+        continue-on-error: true
+      - name: checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # version: v6.0.2
+      - name: Unshallow
+        run: |
+          git fetch --prune --unshallow
+      - name: Download artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # version: v8.0.1
+        with:
+          name: talos-artifacts
+          path: _out
+          run-id: ${{ github.event.workflow_run.id }}

--- a/internal/project/helm/build.go
+++ b/internal/project/helm/build.go
@@ -93,6 +93,8 @@ func (helm *Build) CompileMakefile(output *makefile.Output) error {
 
 	generateTarget := output.GetTarget("generate")
 	if generateTarget != nil {
+		generateTarget.Depends("helm-plugin-install")
+
 		// Only update Chart.yaml for final releases (vX.Y.Z, no pre-release suffix).
 		// This prevents dirty tags, dev builds, and pre-releases from polluting the chart.
 		if helm.meta.ChartVersionMajor != nil {
@@ -176,16 +178,6 @@ fi`, helm.meta.HelmChartDir))
 
 // CompileGitHubWorkflow implements ghworkflow.Compiler.
 func (helm *Build) CompileGitHubWorkflow(output *ghworkflow.Output) error {
-	cosignInstallStep := ghworkflow.Step("Install cosign").
-		SetUsesWithComment(
-			fmt.Sprintf("sigstore/cosign-installer@%s", config.CosignInstallActionRef),
-			"version: "+config.CosignInstallActionVersion,
-		)
-
-	if err := cosignInstallStep.SetConditions("except-pull-request"); err != nil {
-		return err
-	}
-
 	loginStep := ghworkflow.Step("Login to registry").
 		SetUsesWithComment(
 			"docker/login-action@"+config.LoginActionRef,
@@ -245,13 +237,6 @@ func (helm *Build) CompileGitHubWorkflow(output *ghworkflow.Output) error {
 		return err
 	}
 
-	checkDirtyStep := ghworkflow.Step("Check dirty").
-		SetMakeStep("check-dirty")
-
-	if err := checkDirtyStep.SetConditions("on-pull-request"); err != nil {
-		return err
-	}
-
 	// When chartVersionMajor is set, only release stable (non-prerelease) charts.
 	releaseCondition := "only-on-tag"
 	if helm.meta.ChartVersionMajor != nil {
@@ -279,14 +264,6 @@ func (helm *Build) CompileGitHubWorkflow(output *ghworkflow.Output) error {
 
 	jobSteps := []*ghworkflow.JobStep{
 		ghworkflow.SetupBuildxStep(),
-		{
-			Name: "Install Helm",
-			Uses: ghworkflow.ActionRef{
-				Image:   fmt.Sprintf("azure/setup-helm@%s", config.HelmSetupActionRef),
-				Comment: "version: " + config.HelmSetupActionVersion,
-			},
-		},
-		cosignInstallStep,
 		loginStep,
 		lintStep,
 		templateStep,
@@ -307,7 +284,6 @@ func (helm *Build) CompileGitHubWorkflow(output *ghworkflow.Output) error {
 			helmSteps = append(helmSteps, docsStep)
 		}
 
-		helmSteps = append(helmSteps, checkDirtyStep)
 		jobSteps = append(jobSteps, helmSteps...)
 	}
 


### PR DESCRIPTION
Support github matrix jobs.

Other changes:

* Support `workflow_run` triggers
* Cleanup cron and triggered files not managed by kres, fixes: #533
* Drop install of helm and cosign, we already have those in CI build runner
* Always run `check-dirty` and have it depend on `generate`

Other small cleanups.