### PR TITLE
fix: correct tag when building a release PR

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-17T08:42:15Z by kres b6d29bf-dirty.
+# Generated on 2026-04-17T13:38:11Z by kres ae3e740-dirty.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -67,6 +67,10 @@ jobs:
           driver: remote
           endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
         timeout-minutes: 10
+      - name: CI temp release tag
+        if: github.event_name == 'pull_request'
+        run: |
+          make ci-temp-release-tag
       - name: Check dirty
         if: github.event_name == 'pull_request'
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,19 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-17T08:55:31Z by kres 359ab16-dirty.
+# Generated on 2026-04-17T13:38:11Z by kres ae3e740-dirty.
 
 # common variables
 
 SHA := $(shell git describe --match=none --always --abbrev=8 --dirty)
-TAG := $(shell git describe --tag --always --dirty --match v[0-9]\*)
+TAG ?= $(shell git describe --tag --always --dirty --match v[0-9]\*)
 TAG_SUFFIX ?=
-ABBREV_TAG := $(shell git describe --tags >/dev/null 2>/dev/null && git describe --tag --always --match v[0-9]\* --abbrev=0 || echo 'undefined')
+ABBREV_TAG ?= $(shell git describe --tags >/dev/null 2>/dev/null && git describe --tag --always --match v[0-9]\* --abbrev=0 || echo 'undefined')
 BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 ARTIFACTS := _out
 IMAGE_TAG ?= $(TAG)$(TAG_SUFFIX)
 OPERATING_SYSTEM := $(shell uname -s | tr '[:upper:]' '[:lower:]')
 GOARCH := $(shell uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')
+CI_RELEASE_TAG := $(shell git log --oneline --format=%B -n 1 HEAD^2 -- 2>/dev/null | head -n 1 | sed -r "/^release\(.*\)/ s/^release\((.*)\):.*$$/\\1/; t; Q")
 WITH_DEBUG ?= false
 WITH_RACE ?= false
 REGISTRY ?= ghcr.io
@@ -158,6 +159,14 @@ $(ARTIFACTS):  ## Creates artifacts directory.
 .PHONY: clean
 clean:  ## Cleans up all artifacts.
 	@rm -rf $(ARTIFACTS)
+
+.PHONY: ci-temp-release-tag
+ci-temp-release-tag:  ## Generates a temporary release tag for CI run.
+	@if [ -n "$(CI_RELEASE_TAG)" -a -n "$${GITHUB_ENV}" ]; then \
+		echo Setting temporary release tag "$(CI_RELEASE_TAG)"; \
+		echo "TAG=$(CI_RELEASE_TAG)" >> "$${GITHUB_ENV}"; \
+		echo "ABBREV_TAG=$(CI_RELEASE_TAG)" >> "$${GITHUB_ENV}"; \
+	fi
 
 target-%:  ## Builds the specified target defined in the Dockerfile. The build result will only remain in the build cache.
 	@$(BUILD) --target=$* $(COMMON_ARGS) $(TARGET_ARGS) $(CI_ARGS) .

--- a/internal/project/common/build.go
+++ b/internal/project/common/build.go
@@ -63,14 +63,18 @@ func (build *Build) CompileDockerfile(output *dockerfile.Output) error {
 func (build *Build) CompileMakefile(output *makefile.Output) error {
 	variableGroup := output.VariableGroup(makefile.VariableGroupCommon).
 		Variable(makefile.SimpleVariable("SHA", "$(shell git describe --match=none --always --abbrev=8 --dirty)")).
-		Variable(makefile.SimpleVariable("TAG", "$(shell git describe --tag --always --dirty --match v[0-9]\\*)")).
+		Variable(makefile.OverridableVariable("TAG", "$(shell git describe --tag --always --dirty --match v[0-9]\\*)")).
 		Variable(makefile.OverridableVariable("TAG_SUFFIX", "")).
-		Variable(makefile.SimpleVariable("ABBREV_TAG", "$(shell git describe --tags >/dev/null 2>/dev/null && git describe --tag --always --match v[0-9]\\* --abbrev=0 || echo 'undefined')")).
+		Variable(makefile.OverridableVariable("ABBREV_TAG", "$(shell git describe --tags >/dev/null 2>/dev/null && git describe --tag --always --match v[0-9]\\* --abbrev=0 || echo 'undefined')")).
 		Variable(makefile.SimpleVariable("BRANCH", "$(shell git rev-parse --abbrev-ref HEAD)")).
 		Variable(makefile.SimpleVariable("ARTIFACTS", build.ArtifactsPath)).
 		Variable(makefile.OverridableVariable("IMAGE_TAG", "$(TAG)$(TAG_SUFFIX)")).
 		Variable(makefile.SimpleVariable("OPERATING_SYSTEM", "$(shell uname -s | tr '[:upper:]' '[:lower:]')")).
-		Variable(makefile.SimpleVariable("GOARCH", "$(shell uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')"))
+		Variable(makefile.SimpleVariable("GOARCH", "$(shell uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')")).
+		Variable(makefile.SimpleVariable(
+			"CI_RELEASE_TAG",
+			`$(shell git log --oneline --format=%B -n 1 HEAD^2 -- 2>/dev/null | head -n 1 | sed -r "/^release\(.*\)/ s/^release\((.*)\):.*$$/\\1/; t; Q")`,
+		))
 
 	if build.meta.ContainerImageFrontend == config.ContainerImageFrontendDockerfile {
 		variableGroup.Variable(makefile.OverridableVariable("WITH_DEBUG", "false")).
@@ -84,6 +88,15 @@ func (build *Build) CompileMakefile(output *makefile.Output) error {
 	output.Target("clean").
 		Description("Cleans up all artifacts.").
 		Script("@rm -rf $(ARTIFACTS)").
+		Phony()
+
+	output.Target("ci-temp-release-tag").
+		Description("Generates a temporary release tag for CI run.").
+		Script(`@if [ -n "$(CI_RELEASE_TAG)" -a -n "$${GITHUB_ENV}" ]; then \
+	echo Setting temporary release tag "$(CI_RELEASE_TAG)"; \
+	echo "TAG=$(CI_RELEASE_TAG)" >> "$${GITHUB_ENV}"; \
+	echo "ABBREV_TAG=$(CI_RELEASE_TAG)" >> "$${GITHUB_ENV}"; \
+fi`).
 		Phony()
 
 	return nil

--- a/internal/project/common/check_dirty.go
+++ b/internal/project/common/check_dirty.go
@@ -47,6 +47,15 @@ func (c *CheckDirty) CompileGitHubWorkflow(output *ghworkflow.Output) error {
 		return nil
 	}
 
+	ciTempReleaseTagStep := ghworkflow.Step("CI temp release tag").
+		SetMakeStep("ci-temp-release-tag")
+
+	if err := ciTempReleaseTagStep.SetConditions("on-pull-request"); err != nil {
+		return err
+	}
+
+	output.AddStep("default", ciTempReleaseTagStep)
+
 	checkDirtyStep := ghworkflow.Step("Check dirty").
 		SetMakeStep("check-dirty")
 


### PR DESCRIPTION
When building a release PR, set the TAG/ABBREV_TAG to be the future tag, otherwise check-dirty check will not pass.

This is mostly ported from Talos Makefile.

Make TAG/ABBREV_TAG overridable, so that it gets populated from the GitHub environment.