### PR TITLE
fix: pass token for triggered workflows

### DIFF
--- a/internal/project/common/gh_workflow.go
+++ b/internal/project/common/gh_workflow.go
@@ -249,7 +249,8 @@ func (gh *GHWorkflow) CompileGitHubWorkflow(o *ghworkflow.Output) error {
 						SetWith("path", step.ArtifactStep.ArtifactPath)
 
 					if step.ArtifactStep.RunID != "" {
-						downloadArtifactsStep.SetWith("run-id", step.ArtifactStep.RunID)
+						downloadArtifactsStep.SetWith("run-id", step.ArtifactStep.RunID).
+							SetWith("github-token", "${{ secrets.GITHUB_TOKEN }}")
 					}
 
 					if step.ContinueOnError {
@@ -556,11 +557,13 @@ func (gh *GHWorkflow) CompileGitHubWorkflow(o *ghworkflow.Output) error {
 			o.AddSlackNotifyForFailure(workflowName)
 
 			triggeredJob := &ghworkflow.Job{
-				If:          "github.event.workflow_run.conclusion == 'success'",
-				RunsOn:      ghworkflow.NewRunsOnGroupLabel(job.RunnerGroup, ""),
-				Permissions: ghworkflow.DefaultJobPermissions(),
-				Services:    jobDef.Services,
-				Steps:       injectTriggeredRunID(jobDef.Steps),
+				If:     "github.event.workflow_run.conclusion == 'success'",
+				RunsOn: ghworkflow.NewRunsOnGroupLabel(job.RunnerGroup, ""),
+				Permissions: map[string]string{
+					"actions": "read",
+				},
+				Services: jobDef.Services,
+				Steps:    injectTriggeredRunID(jobDef.Steps),
 			}
 
 			if job.Matrix != nil {
@@ -758,7 +761,8 @@ func compileFlatJobSteps(job Job, entry MatrixEntry, baseSteps []*ghworkflow.Job
 					SetWith("path", step.ArtifactStep.ArtifactPath)
 
 				if step.ArtifactStep.RunID != "" {
-					dlStep.SetWith("run-id", matrixSubstFull(step.ArtifactStep.RunID, entry))
+					dlStep.SetWith("run-id", matrixSubstFull(step.ArtifactStep.RunID, entry)).
+						SetWith("github-token", "${{ secrets.GITHUB_TOKEN }}")
 				}
 
 				if step.ContinueOnError {
@@ -928,6 +932,7 @@ func injectTriggeredRunID(steps []*ghworkflow.JobStep) []*ghworkflow.JobStep {
 				maps.Copy(clone.With, step.With)
 
 				clone.With["run-id"] = "${{ github.event.workflow_run.id }}"
+				clone.With["github-token"] = "${{ secrets.GITHUB_TOKEN }}"
 				result[i] = &clone
 
 				continue

--- a/internal/project/common/testdata/TestArtifactStepRunID/integration-provision-triggered.yaml
+++ b/internal/project/common/testdata/TestArtifactStepRunID/integration-provision-triggered.yaml
@@ -16,10 +16,6 @@ jobs:
   default:
     permissions:
       actions: read
-      contents: write
-      issues: read
-      packages: write
-      pull-requests: read
     runs-on:
       group: large
     if: github.event.workflow_run.conclusion == 'success'
@@ -57,6 +53,7 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # version: v8.0.1
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           name: talos-artifacts
           path: _out
           run-id: ${{ github.event.workflow_run.id || github.run_id }}

--- a/internal/project/common/testdata/TestTriggeredRunIDAutoInject/integration-qemu-race-triggered.yaml
+++ b/internal/project/common/testdata/TestTriggeredRunIDAutoInject/integration-qemu-race-triggered.yaml
@@ -16,10 +16,6 @@ jobs:
   default:
     permissions:
       actions: read
-      contents: write
-      issues: read
-      packages: write
-      pull-requests: read
     runs-on:
       group: large
     if: github.event.workflow_run.conclusion == 'success'
@@ -57,6 +53,7 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # version: v8.0.1
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           name: talos-artifacts
           path: _out
           run-id: ${{ github.event.workflow_run.id }}


### PR DESCRIPTION
Pass token for triggered workflows so that it can download artifacts. Also drop excessive permissions for triggered jobs.