### PR TITLE
feat: support flat job matrices

### DIFF
--- a/internal/output/ghworkflow/types.go
+++ b/internal/output/ghworkflow/types.go
@@ -89,8 +89,8 @@ type Push struct {
 // Strategy represents GitHub Actions job strategy.
 type Strategy struct {
 	Matrix      *StrategyMatrix `yaml:"matrix,omitempty"`
+	FailFast    *bool           `yaml:"fail-fast,omitempty"`
 	MaxParallel int             `yaml:"max-parallel,omitempty"`
-	FailFast    bool            `yaml:"fail-fast,omitempty"`
 }
 
 // StrategyMatrix represents GitHub Actions strategy matrix.
@@ -100,6 +100,7 @@ type StrategyMatrix struct {
 
 // Job represents GitHub Actions job.
 type Job struct {
+	Name        string             `yaml:"name,omitempty"`
 	Permissions map[string]string  `yaml:"permissions,omitempty"`
 	RunsOn      RunsOn             `yaml:"runs-on"`
 	If          string             `yaml:"if,omitempty"`

--- a/internal/output/github/github.go
+++ b/internal/output/github/github.go
@@ -46,13 +46,10 @@ func (o *Output) Generate() error {
 	return nil
 }
 
-// Compile implements [output.TypedWriter] interface.
+// Compile implements [output.TypedWriter] interface. The client may be nil
+// when GITHUB_TOKEN is not set; compilers are expected to treat a nil client
+// as dry-run (print intended state, skip API calls).
 func (o *Output) Compile(compiler Compiler) error {
-	if o.client == nil {
-		// no token, skip it
-		return nil
-	}
-
 	return compiler.CompileGitHub(o.client)
 }
 

--- a/internal/project/auto/ci.go
+++ b/internal/project/auto/ci.go
@@ -41,10 +41,14 @@ func (builder *builder) DetectCI() (bool, error) {
 func (builder *builder) BuildCI() error {
 	var targets []dag.Node
 
-	targets = append(targets, common.NewGHWorkflow(builder.meta))
+	ghw := common.NewGHWorkflow(builder.meta)
+	targets = append(targets, ghw)
 
 	if builder.meta.CompileGithubWorkflowsOnly {
-		targets = append(targets, common.NewRepository(builder.meta))
+		repo := common.NewRepository(builder.meta)
+		repo.SetAutoContextsFunc(ghw.CollectEnforceContexts)
+		repo.SetAutoLabelsFunc(ghw.CollectTriggerLabels)
+		targets = append(targets, repo)
 		targets = append(targets, common.NewSOPS(builder.meta))
 		targets = append(targets, common.NewRenovate(builder.meta))
 	}

--- a/internal/project/auto/git.go
+++ b/internal/project/auto/git.go
@@ -57,6 +57,10 @@ func (builder *builder) DetectGit() (bool, error) {
 		builder.meta.MainBranch = main
 	}
 
+	if head, headErr := repo.Head(); headErr == nil && head.Name().IsBranch() {
+		builder.meta.CurrentBranch = head.Name().Short()
+	}
+
 	remotes, err := repo.Remotes()
 	if err != nil {
 		return true, err

--- a/internal/project/common/gh_workflow.go
+++ b/internal/project/common/gh_workflow.go
@@ -9,6 +9,7 @@ import (
 	"maps"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/siderolabs/gen/xslices"
@@ -56,9 +57,10 @@ type MatrixInclude struct {
 // Matrix configures a GitHub Actions matrix strategy on a triggered workflow,
 // and controls how ci.yaml expands the matrix into individual jobs.
 type Matrix struct {
-	Include     []MatrixInclude `yaml:"include"`
-	LabelKeys   []string        `yaml:"labelKeys,omitempty"`
-	MaxParallel int             `yaml:"maxParallel"`
+	Include       []MatrixInclude `yaml:"include"`
+	LabelKeys     []string        `yaml:"labelKeys,omitempty"`
+	MaxParallel   int             `yaml:"maxParallel"`
+	FlatJobMatrix bool            `yaml:"flatJobMatrix,omitempty"`
 }
 
 // OnWorkflowRun defines options for workflow_run triggers.
@@ -138,6 +140,11 @@ type GHWorkflow struct {
 	CIFailuresSlackNotifyChannel string `yaml:"ciFailuresSlackNotifyChannel,omitempty"`
 	CustomRunnerGroup            string `yaml:"customRunnerGroup,omitempty"`
 
+	// LabelDescriptions maps PR trigger label names to human-readable
+	// descriptions. Used by repository.enableLabels to set descriptions when
+	// creating/updating labels.
+	LabelDescriptions map[string]string `yaml:"labelDescriptions,omitempty"`
+
 	Jobs []Job `yaml:"jobs"`
 }
 
@@ -153,6 +160,84 @@ func NewGHWorkflow(meta *meta.Options) *GHWorkflow {
 
 		meta: meta,
 	}
+}
+
+// CollectEnforceContexts returns the list of GitHub Actions check names for
+// all jobs defined in this workflow, including per-entry names for flat-expanded
+// and flatJobMatrix matrix jobs. Jobs that don't run on pull requests (cronOnly
+// or gated by conditions that exclude PRs) are skipped. The result is suitable
+// for use as required status checks in branch protection.
+func (gh *GHWorkflow) CollectEnforceContexts() []string {
+	var contexts []string
+
+	for _, job := range gh.Jobs {
+		// Skip jobs that can never produce a PR status check:
+		//   - cronOnly: scheduled-only, not in ci.yaml
+		//   - Dispatchable: workflow_dispatch only (dispatch.yaml, not ci.yaml)
+		//   - Conditions that explicitly exclude PRs (only-on-*, except-pull-request)
+		if job.CronOnly || job.Dispatchable {
+			continue
+		}
+
+		// Conditions default to running on PRs when unset; explicit conditions
+		// must include "on-pull-request" to qualify as a PR status check.
+		if len(job.Conditions) > 0 && !slices.Contains(job.Conditions, "on-pull-request") {
+			continue
+		}
+
+		if job.Matrix == nil || len(job.Matrix.LabelKeys) == 0 {
+			contexts = append(contexts, job.Name)
+
+			continue
+		}
+
+		for _, entry := range job.Matrix.Include {
+			parts := make([]string, 0, len(job.Matrix.LabelKeys))
+
+			for _, k := range job.Matrix.LabelKeys {
+				if v := entry.Values[k]; v != "" {
+					parts = append(parts, v)
+				}
+			}
+
+			suffix := strings.Join(parts, "-")
+
+			if job.Matrix.FlatJobMatrix {
+				contexts = append(contexts, suffix)
+			} else {
+				contexts = append(contexts, job.Name+"-"+suffix)
+			}
+		}
+	}
+
+	return contexts
+}
+
+// CollectTriggerLabels returns the deduplicated set of PR labels referenced as
+// job-level TriggerLabels or per-entry matrix TriggerLabels, mapped to their
+// description (taken from GHWorkflow.LabelDescriptions; empty string if none).
+// The result is suitable for provisioning the corresponding labels on the
+// GitHub repository.
+func (gh *GHWorkflow) CollectTriggerLabels() map[string]string {
+	labels := map[string]string{}
+
+	for _, job := range gh.Jobs {
+		for _, l := range job.TriggerLabels {
+			labels[l] = gh.LabelDescriptions[l]
+		}
+
+		if job.Matrix == nil {
+			continue
+		}
+
+		for _, entry := range job.Matrix.Include {
+			for _, l := range entry.TriggerLabels {
+				labels[l] = gh.LabelDescriptions[l]
+			}
+		}
+	}
+
+	return labels
 }
 
 // CompileGitHubWorkflow implements ghworkflow.Compiler.
@@ -471,9 +556,13 @@ func (gh *GHWorkflow) CompileGitHubWorkflow(o *ghworkflow.Output) error {
 				return fmt.Errorf("job %s has triggerLabels but no depends", job.Name)
 			}
 
-			for _, dep := range job.Depends {
-				if _, ok := touchedJobs[dep]; !ok {
-					o.AddStep(dep,
+			// The if: condition reads from needs.default.outputs.labels, so only
+			// the "default" job (if it's a dep) needs the retrieve-pr-labels step.
+			const labelProvider = ghworkflow.DefaultJobName
+
+			if slices.Contains(job.Depends, labelProvider) {
+				if _, ok := touchedJobs[labelProvider]; !ok {
+					o.AddStep(labelProvider,
 						ghworkflow.Step("Retrieve PR labels").
 							SetID("retrieve-pr-labels").
 							SetUsesWithComment(
@@ -484,15 +573,15 @@ func (gh *GHWorkflow) CompileGitHubWorkflow(o *ghworkflow.Output) error {
 							SetWith("script", strings.TrimPrefix(ghworkflow.IssueLabelRetrieveScript, "\n")),
 					)
 
-					o.AddOutputs(dep, map[string]string{
+					o.AddOutputs(labelProvider, map[string]string{
 						"labels": "${{ steps.retrieve-pr-labels.outputs.result }}",
 					})
 
-					touchedJobs[dep] = struct{}{}
+					touchedJobs[labelProvider] = struct{}{}
 				}
 			}
 
-			if job.Matrix != nil && len(job.Matrix.LabelKeys) > 0 {
+			if job.Matrix != nil && len(job.Matrix.LabelKeys) > 0 && !job.Matrix.FlatJobMatrix {
 				// Flat job expansion: emit one individual ci.yaml job per matrix entry.
 				// Job-level triggerLabels fire all flat jobs; per-entry TriggerLabels
 				// fire only that specific entry's flat job.
@@ -543,6 +632,36 @@ func (gh *GHWorkflow) CompileGitHubWorkflow(o *ghworkflow.Output) error {
 				})
 
 				jobDef.If = strings.Join(conditions, " || ")
+
+				if job.Matrix != nil && job.Matrix.FlatJobMatrix {
+					failFast := false
+
+					jobDef.Strategy = &ghworkflow.Strategy{
+						MaxParallel: job.Matrix.MaxParallel,
+						FailFast:    &failFast,
+						Matrix: &ghworkflow.StrategyMatrix{
+							Include: xslices.Map(job.Matrix.Include, func(e MatrixInclude) map[string]string {
+								result := make(map[string]string, len(e.Values))
+								for k, v := range e.Values {
+									if v != "" {
+										result[k] = v
+									}
+								}
+
+								return result
+							}),
+						},
+					}
+
+					if len(job.Matrix.LabelKeys) > 0 {
+						parts := make([]string, 0, len(job.Matrix.LabelKeys))
+						for _, k := range job.Matrix.LabelKeys {
+							parts = append(parts, "${{ matrix."+k+" }}")
+						}
+
+						jobDef.Name = strings.Join(parts, "-")
+					}
+				}
 			}
 		}
 
@@ -567,13 +686,38 @@ func (gh *GHWorkflow) CompileGitHubWorkflow(o *ghworkflow.Output) error {
 			}
 
 			if job.Matrix != nil {
+				failFast := false
+
 				triggeredJob.Strategy = &ghworkflow.Strategy{
 					MaxParallel: job.Matrix.MaxParallel,
+					FailFast:    &failFast,
 					Matrix: &ghworkflow.StrategyMatrix{
 						Include: xslices.Map(job.Matrix.Include, func(e MatrixInclude) map[string]string {
-							return map[string]string(e.Values)
+							result := make(map[string]string, len(e.Values))
+							for k, v := range e.Values {
+								if v != "" {
+									result[k] = v
+								}
+							}
+
+							return result
 						}),
 					},
+				}
+
+				if len(job.Matrix.LabelKeys) > 0 {
+					parts := make([]string, 0, len(job.Matrix.LabelKeys))
+					for _, k := range job.Matrix.LabelKeys {
+						parts = append(parts, "${{ matrix."+k+" }}")
+					}
+
+					triggeredJob.Name = strings.Join(parts, "-")
+				} else if len(job.Matrix.Include) > 0 {
+					for k := range job.Matrix.Include[0].Values {
+						triggeredJob.Name = "${{ matrix." + k + " }}"
+
+						break
+					}
 				}
 			}
 

--- a/internal/project/common/gh_workflow_test.go
+++ b/internal/project/common/gh_workflow_test.go
@@ -238,6 +238,89 @@ func TestArtifactStepRunID(t *testing.T) {
 	assertGolden(t, "integration-provision-triggered.yaml", buf.Bytes())
 }
 
+// TestTriggeredWorkflowMatrixFailFast verifies that a triggered workflow with a
+// matrix strategy has fail-fast: false so that one entry failing does not cancel
+// the remaining entries.
+func TestTriggeredWorkflowMatrixFailFast(t *testing.T) {
+	jobs := []common.Job{
+		{
+			Name:        "integration-misc-3",
+			RunnerGroup: "large",
+			Depends:     []string{"default"},
+			TriggerLabels: []string{
+				"integration/misc-3",
+			},
+			OnWorkflowRun: &common.OnWorkflowRun{
+				Workflows: []string{"artifacts-cron"},
+				Types:     []string{"completed"},
+			},
+			Matrix: &common.Matrix{
+				MaxParallel: 1,
+				LabelKeys:   []string{"variant"},
+				Include: []common.MatrixInclude{
+					{Values: common.MatrixEntry{"variant": "default"}},
+					{Values: common.MatrixEntry{"variant": "enforcing", "buildEnforcing": "true"}},
+				},
+			},
+			Steps: []common.Step{
+				{Name: "run-tests", Command: "e2e-${{ matrix.variant }}"},
+			},
+		},
+	}
+
+	o := compileWorkflow(t, jobs)
+
+	var buf bytes.Buffer
+
+	require.NoError(t, o.GenerateFile(".github/workflows/integration-misc-3-triggered.yaml", &buf))
+	assertGolden(t, "integration-misc-3-triggered.yaml", buf.Bytes())
+}
+
+// TestFlatJobMatrix verifies that a job with flatJobMatrix: true emits a matrix
+// strategy in ci.yaml (with max-parallel and fail-fast: false) instead of flat
+// job expansion, and that the name field is set from labelKeys.
+func TestFlatJobMatrix(t *testing.T) {
+	jobs := []common.Job{
+		{
+			Name:        "integration-misc-0",
+			RunnerGroup: "large",
+			Depends:     []string{"default"},
+			TriggerLabels: []string{
+				"integration/misc-0",
+			},
+			Matrix: &common.Matrix{
+				MaxParallel:   2,
+				FlatJobMatrix: true,
+				LabelKeys:     []string{"test"},
+				Include: []common.MatrixInclude{
+					{Values: common.MatrixEntry{"test": "e2e-firewall", "shortIntegrationTest": "yes"}},
+					{Values: common.MatrixEntry{"test": "e2e-canal-reset", "integrationTestRun": "TestIntegration/api.ResetSuite/TestResetWithSpec"}},
+					{Values: common.MatrixEntry{"test": "e2e-controlplane-port", "shortIntegrationTest": "yes", "withControlPlanePort": "443"}},
+				},
+			},
+			Steps: []common.Step{
+				{
+					Name:     "e2e-qemu",
+					Command:  "e2e-qemu",
+					WithSudo: true,
+					Environment: map[string]string{
+						"SHORT_INTEGRATION_TEST":  "${{ matrix.shortIntegrationTest }}",
+						"INTEGRATION_TEST_RUN":    "${{ matrix.integrationTestRun }}",
+						"WITH_CONTROL_PLANE_PORT": "${{ matrix.withControlPlanePort }}",
+					},
+				},
+			},
+		},
+	}
+
+	o := compileWorkflow(t, jobs)
+
+	var buf bytes.Buffer
+
+	require.NoError(t, o.GenerateFile(ghworkflow.CiWorkflow, &buf))
+	assertGolden(t, "ci.yaml", buf.Bytes())
+}
+
 // TestMatrixPerEntryTriggerLabels verifies that per-entry TriggerLabels fire only
 // the matching flat job, while job-level TriggerLabels fire all flat jobs.
 // This tests the combined oss/nonfree scenario where integration/aws-nvidia-oss must

--- a/internal/project/common/repository.go
+++ b/internal/project/common/repository.go
@@ -7,8 +7,10 @@ package common
 import (
 	"context"
 	"fmt"
+	"maps"
 	"net/http"
 	"slices"
+	"strings"
 
 	"github.com/google/go-github/v84/github"
 	"github.com/siderolabs/gen/xslices"
@@ -28,8 +30,21 @@ type Repository struct { //nolint:govet
 
 	meta *meta.Options
 
-	MainBranch        string                  `yaml:"mainBranch"`
-	ProtectedBranches []ProtectedBranchConfig `yaml:"protectedBranches"`
+	// autoContextsFunc returns additional status check contexts to enforce,
+	// computed at compile time (e.g. from GHWorkflow jobs).
+	autoContextsFunc func() []string
+
+	// autoLabelsFunc returns PR trigger labels that should exist on the
+	// repository, mapped to their description (empty string if unset). Computed
+	// at compile time (e.g. from GHWorkflow jobs).
+	autoLabelsFunc func() map[string]string
+
+	MainBranch string `yaml:"mainBranch"`
+
+	// DryRun, when true, logs the intended branch protection / conform changes
+	// instead of calling the GitHub API. Dry-run is also implicit when
+	// GITHUB_TOKEN is unset.
+	DryRun bool `yaml:"dryRun,omitempty"`
 
 	EnableConform             bool     `yaml:"enableConform"`
 	ConformWebhookURL         string   `yaml:"conformWebhookURL"`
@@ -49,12 +64,6 @@ type Repository struct { //nolint:govet
 	BotName string `yaml:"botName"`
 
 	SkipStaleWorkflow bool `yaml:"skipStaleWorkflow"`
-}
-
-// ProtectedBranchConfig configures branch protection for a specific branch.
-type ProtectedBranchConfig struct {
-	Name            string   `yaml:"name"`
-	EnforceContexts []string `yaml:"enforceContexts"`
 }
 
 // LicenseConfig configures the license.
@@ -172,10 +181,24 @@ func (r *Repository) CompileLicense(o *license.Output) error {
 	return nil
 }
 
-// CompileGitHub implements github.Compiler.
+// CompileGitHub implements github.Compiler. When Repository.DryRun is true,
+// changes are logged instead of applied. When GITHUB_TOKEN is unset and
+// DryRun is false, the step is skipped entirely.
 func (r *Repository) CompileGitHub(client *github.Client) error {
+	if client == nil && !r.DryRun {
+		return nil
+	}
+
 	if err := r.enableBranchProtection(client); err != nil {
 		return err
+	}
+
+	if err := r.enableLabels(client); err != nil {
+		return err
+	}
+
+	if r.DryRun {
+		return nil
 	}
 
 	if r.EnableConform {
@@ -188,16 +211,98 @@ func (r *Repository) CompileGitHub(client *github.Client) error {
 }
 
 func (r *Repository) enableBranchProtection(client *github.Client) error {
-	branches := r.ProtectedBranches
-	if len(branches) == 0 {
-		branches = []ProtectedBranchConfig{{Name: r.MainBranch}}
+	// When kres runs from a release-* branch, protect that branch; otherwise
+	// protect main.
+	targetBranch := r.MainBranch
+	if strings.HasPrefix(r.meta.CurrentBranch, "release-") {
+		targetBranch = r.meta.CurrentBranch
 	}
 
-	for _, branch := range branches {
-		enforceContexts := r.buildEnforceContexts(branch.EnforceContexts)
+	enforceContexts := r.buildEnforceContexts(nil)
 
-		if err := r.applyBranchProtection(client, branch.Name, enforceContexts); err != nil {
-			return err
+	if r.DryRun {
+		fmt.Printf("dry-run: branch protection for %s would require %d contexts:\n", targetBranch, len(enforceContexts))
+
+		for _, c := range enforceContexts {
+			fmt.Printf("  - %s\n", c)
+		}
+
+		return nil
+	}
+
+	return r.applyBranchProtection(client, targetBranch, enforceContexts)
+}
+
+// SetAutoContextsFunc registers a callback that supplies auto-computed status
+// check contexts (e.g. from GHWorkflow jobs). The callback is invoked at compile
+// time, after the DAG has been loaded from .kres.yaml.
+func (r *Repository) SetAutoContextsFunc(fn func() []string) {
+	r.autoContextsFunc = fn
+}
+
+// SetAutoLabelsFunc registers a callback that supplies auto-computed PR labels
+// (e.g. trigger labels from GHWorkflow jobs) mapped to their description. The
+// callback is invoked at compile time, after the DAG has been loaded from
+// .kres.yaml.
+func (r *Repository) SetAutoLabelsFunc(fn func() map[string]string) {
+	r.autoLabelsFunc = fn
+}
+
+// autoLabelColor is the default color for labels created automatically by kres.
+const autoLabelColor = "ededed"
+
+func (r *Repository) enableLabels(client *github.Client) error {
+	if r.autoLabelsFunc == nil {
+		return nil
+	}
+
+	labels := r.autoLabelsFunc()
+	if len(labels) == 0 {
+		return nil
+	}
+
+	names := slices.Sorted(maps.Keys(labels))
+
+	if r.DryRun {
+		fmt.Printf("dry-run: repository would ensure %d PR labels exist:\n", len(names))
+
+		for _, name := range names {
+			if desc := labels[name]; desc != "" {
+				fmt.Printf("  - %s — %s\n", name, desc)
+			} else {
+				fmt.Printf("  - %s\n", name)
+			}
+		}
+
+		return nil
+	}
+
+	for _, name := range names {
+		desc := labels[name]
+
+		existing, resp, err := client.Issues.GetLabel(context.Background(), r.meta.GitHubOrganization, r.meta.GitHubRepository, name)
+		if err != nil {
+			if resp == nil || resp.StatusCode != http.StatusNotFound {
+				return fmt.Errorf("failed to check label %q: %w", name, err)
+			}
+
+			if _, _, err := client.Issues.CreateLabel(context.Background(), r.meta.GitHubOrganization, r.meta.GitHubRepository, &github.Label{
+				Name:        new(name),
+				Color:       new(autoLabelColor),
+				Description: new(desc),
+			}); err != nil {
+				return fmt.Errorf("failed to create label %q: %w", name, err)
+			}
+
+			continue
+		}
+
+		if desc != "" && existing.GetDescription() != desc {
+			if _, _, err := client.Issues.EditLabel(context.Background(), r.meta.GitHubOrganization, r.meta.GitHubRepository, name, &github.Label{
+				Description: new(desc),
+			}); err != nil {
+				return fmt.Errorf("failed to update description for label %q: %w", name, err)
+			}
 		}
 	}
 
@@ -206,6 +311,10 @@ func (r *Repository) enableBranchProtection(client *github.Client) error {
 
 func (r *Repository) buildEnforceContexts(base []string) []string {
 	enforceContexts := base
+
+	if r.autoContextsFunc != nil {
+		enforceContexts = append(enforceContexts, r.autoContextsFunc()...)
+	}
 
 	switch r.meta.CIProvider {
 	case config.CIProviderDrone:

--- a/internal/project/common/testdata/TestFlatJobMatrix/ci.yaml
+++ b/internal/project/common/testdata/TestFlatJobMatrix/ci.yaml
@@ -1,0 +1,148 @@
+# THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
+#
+# Generated on 2006-01-02T15:04:05Z by test.
+
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+"on":
+  push:
+    branches:
+      - main
+      - release-*
+    tags:
+      - v*
+  pull_request:
+    branches:
+      - main
+      - release-*
+name: default
+jobs:
+  default:
+    permissions:
+      actions: read
+      contents: write
+      issues: read
+      packages: write
+      pull-requests: read
+    runs-on:
+      group: generic
+    if: (!startsWith(github.head_ref, 'renovate/') && !startsWith(github.head_ref, 'dependabot/'))
+    outputs:
+      labels: ${{ steps.retrieve-pr-labels.outputs.result }}
+    steps:
+      - name: gather-system-info
+        id: system-info
+        uses: kenchan0130/actions-system-info@59699597e84e80085a750998045983daa49274c4 # version: v1.4.0
+        continue-on-error: true
+      - name: print-system-info
+        run: |
+          MEMORY_GB=$((${{ steps.system-info.outputs.totalmem }}/1024/1024/1024))
+
+          OUTPUTS=(
+            "CPU Core: ${{ steps.system-info.outputs.cpu-core }}"
+            "CPU Model: ${{ steps.system-info.outputs.cpu-model }}"
+            "Hostname: ${{ steps.system-info.outputs.hostname }}"
+            "NodeName: ${NODE_NAME}"
+            "Kernel release: ${{ steps.system-info.outputs.kernel-release }}"
+            "Kernel version: ${{ steps.system-info.outputs.kernel-version }}"
+            "Name: ${{ steps.system-info.outputs.name }}"
+            "Platform: ${{ steps.system-info.outputs.platform }}"
+            "Release: ${{ steps.system-info.outputs.release }}"
+            "Total memory: ${MEMORY_GB} GB"
+          )
+
+          for OUTPUT in "${OUTPUTS[@]}";do
+            echo "${OUTPUT}"
+          done
+        continue-on-error: true
+      - name: checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # version: v6.0.2
+      - name: Unshallow
+        run: |
+          git fetch --prune --unshallow
+      - name: Set up Docker Buildx
+        id: setup-buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # version: v4.0.0
+        with:
+          driver: remote
+          endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
+        timeout-minutes: 10
+      - name: Retrieve PR labels
+        id: retrieve-pr-labels
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # version: v8.0.0
+        with:
+          retries: "3"
+          script: |
+            if (context.eventName != "pull_request") { return "[]" }
+
+            const resp = await github.rest.issues.get({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+            })
+
+            return resp.data.labels.map(label => label.name)
+  integration-misc-0:
+    name: ${{ matrix.test }}
+    permissions:
+      actions: read
+      contents: write
+      issues: read
+      packages: write
+      pull-requests: read
+    runs-on:
+      group: large
+    if: contains(fromJSON(needs.default.outputs.labels), 'integration/misc-0')
+    strategy:
+      matrix:
+        include:
+          - shortIntegrationTest: "yes"
+            test: e2e-firewall
+          - integrationTestRun: TestIntegration/api.ResetSuite/TestResetWithSpec
+            test: e2e-canal-reset
+          - shortIntegrationTest: "yes"
+            test: e2e-controlplane-port
+            withControlPlanePort: "443"
+      fail-fast: false
+      max-parallel: 2
+    needs:
+      - default
+    steps:
+      - name: gather-system-info
+        id: system-info
+        uses: kenchan0130/actions-system-info@59699597e84e80085a750998045983daa49274c4 # version: v1.4.0
+        continue-on-error: true
+      - name: print-system-info
+        run: |
+          MEMORY_GB=$((${{ steps.system-info.outputs.totalmem }}/1024/1024/1024))
+
+          OUTPUTS=(
+            "CPU Core: ${{ steps.system-info.outputs.cpu-core }}"
+            "CPU Model: ${{ steps.system-info.outputs.cpu-model }}"
+            "Hostname: ${{ steps.system-info.outputs.hostname }}"
+            "NodeName: ${NODE_NAME}"
+            "Kernel release: ${{ steps.system-info.outputs.kernel-release }}"
+            "Kernel version: ${{ steps.system-info.outputs.kernel-version }}"
+            "Name: ${{ steps.system-info.outputs.name }}"
+            "Platform: ${{ steps.system-info.outputs.platform }}"
+            "Release: ${{ steps.system-info.outputs.release }}"
+            "Total memory: ${MEMORY_GB} GB"
+          )
+
+          for OUTPUT in "${OUTPUTS[@]}";do
+            echo "${OUTPUT}"
+          done
+        continue-on-error: true
+      - name: checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # version: v6.0.2
+      - name: Unshallow
+        run: |
+          git fetch --prune --unshallow
+      - name: e2e-qemu
+        env:
+          INTEGRATION_TEST_RUN: ${{ matrix.integrationTestRun }}
+          SHORT_INTEGRATION_TEST: ${{ matrix.shortIntegrationTest }}
+          WITH_CONTROL_PLANE_PORT: ${{ matrix.withControlPlanePort }}
+        run: |
+          sudo -E make e2e-qemu

--- a/internal/project/common/testdata/TestTriggeredWorkflowMatrixFailFast/integration-misc-3-triggered.yaml
+++ b/internal/project/common/testdata/TestTriggeredWorkflowMatrixFailFast/integration-misc-3-triggered.yaml
@@ -1,0 +1,64 @@
+# THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
+#
+# Generated on 2006-01-02T15:04:05Z by test.
+
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+"on":
+  workflow_run:
+    workflows:
+      - artifacts-cron
+    types:
+      - completed
+name: integration-misc-3-triggered
+jobs:
+  default:
+    name: ${{ matrix.variant }}
+    permissions:
+      actions: read
+    runs-on:
+      group: large
+    if: github.event.workflow_run.conclusion == 'success'
+    strategy:
+      matrix:
+        include:
+          - variant: default
+          - buildEnforcing: "true"
+            variant: enforcing
+      fail-fast: false
+      max-parallel: 1
+    steps:
+      - name: gather-system-info
+        id: system-info
+        uses: kenchan0130/actions-system-info@59699597e84e80085a750998045983daa49274c4 # version: v1.4.0
+        continue-on-error: true
+      - name: print-system-info
+        run: |
+          MEMORY_GB=$((${{ steps.system-info.outputs.totalmem }}/1024/1024/1024))
+
+          OUTPUTS=(
+            "CPU Core: ${{ steps.system-info.outputs.cpu-core }}"
+            "CPU Model: ${{ steps.system-info.outputs.cpu-model }}"
+            "Hostname: ${{ steps.system-info.outputs.hostname }}"
+            "NodeName: ${NODE_NAME}"
+            "Kernel release: ${{ steps.system-info.outputs.kernel-release }}"
+            "Kernel version: ${{ steps.system-info.outputs.kernel-version }}"
+            "Name: ${{ steps.system-info.outputs.name }}"
+            "Platform: ${{ steps.system-info.outputs.platform }}"
+            "Release: ${{ steps.system-info.outputs.release }}"
+            "Total memory: ${MEMORY_GB} GB"
+          )
+
+          for OUTPUT in "${OUTPUTS[@]}";do
+            echo "${OUTPUT}"
+          done
+        continue-on-error: true
+      - name: checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # version: v6.0.2
+      - name: Unshallow
+        run: |
+          git fetch --prune --unshallow
+      - name: run-tests
+        run: |
+          make e2e-${{ matrix.variant }}

--- a/internal/project/meta/meta.go
+++ b/internal/project/meta/meta.go
@@ -23,6 +23,10 @@ type Options struct { //nolint:govet
 	// Git settings.
 	MainBranch string
 
+	// CurrentBranch is the currently checked-out git branch (short name).
+	// Empty when running outside a git checkout or on a detached HEAD.
+	CurrentBranch string
+
 	// CanonicalPaths, import path for Go projects.
 	CanonicalPaths []string
 


### PR DESCRIPTION
This PR adds a significant number of features:

* Support matrix jobs in default set of jobs in addition to supporting `workflow_run` based matrix jobs
* Set `fail-fast: false` so one matrix job failure doesn't cancel existing running ones
* Automatically generate required checks from current job definitions.
* Handle `release-*` branches separately so it gets it's own required checks and branch protections.
* Support auto-adding labels based on `triggerLabels` defined
* Support setting label descriptions
* Support `dryRun` for `common.Repository` to print labels and required checks it would add
* Fix bug where we add multiple retrieve PR label steps