### PR TITLE
fix: flatjob matrices

### DIFF
--- a/internal/output/github/github.go
+++ b/internal/output/github/github.go
@@ -47,8 +47,9 @@ func (o *Output) Generate() error {
 }
 
 // Compile implements [output.TypedWriter] interface. The client may be nil
-// when GITHUB_TOKEN is not set; compilers are expected to treat a nil client
-// as dry-run (print intended state, skip API calls).
+// when GITHUB_TOKEN is not set, which disables GitHub API integration. The
+// nil client is forwarded to the compiler as-is; dry-run behavior must be
+// opted into explicitly by the compiler.
 func (o *Output) Compile(compiler Compiler) error {
 	return compiler.CompileGitHub(o.client)
 }

--- a/internal/output/makefile/makefile.go
+++ b/internal/output/makefile/makefile.go
@@ -55,8 +55,14 @@ func (o *Output) VariableGroup(description string) *VariableGroup {
 	return o.variableGroups[description]
 }
 
-// Target creates new Makefile target.
+// Target returns an existing Makefile target by name, or creates a new one.
 func (o *Output) Target(name string) *Target {
+	for _, target := range o.targets {
+		if target.name == name {
+			return target
+		}
+	}
+
 	target := &Target{name: name}
 
 	o.targets = append(o.targets, target)
@@ -69,17 +75,6 @@ func (o *Output) HasTarget(name string) bool {
 	return slices.ContainsFunc(o.targets, func(t *Target) bool {
 		return t.name == name
 	})
-}
-
-// GetTarget returns target by name.
-func (o *Output) GetTarget(name string) *Target {
-	for _, target := range o.targets {
-		if target.name == name {
-			return target
-		}
-	}
-
-	return nil
 }
 
 // IfTrueCondition creates new Makefile condition.

--- a/internal/project/common/check_dirty.go
+++ b/internal/project/common/check_dirty.go
@@ -34,10 +34,17 @@ func (c *CheckDirty) CompileMakefile(output *makefile.Output) error {
 		return nil
 	}
 
-	output.Target("check-dirty").
+	checkDirtyTarget := output.Target("check-dirty").
 		Phony().
-		Depends("generate").
 		Script("@if test -n \"`git status --porcelain`\"; then echo \"Source tree is dirty\"; git status; git diff; exit 1 ; fi")
+
+	for _, parent := range c.Parents() {
+		if dag.FindByName("protobuf", parent.Inputs()...) != nil {
+			checkDirtyTarget.Depends("generate")
+
+			break
+		}
+	}
 
 	return nil
 }

--- a/internal/project/common/gh_workflow.go
+++ b/internal/project/common/gh_workflow.go
@@ -200,6 +200,10 @@ func (gh *GHWorkflow) CollectEnforceContexts() []string {
 				}
 			}
 
+			if len(parts) == 0 {
+				continue
+			}
+
 			suffix := strings.Join(parts, "-")
 
 			if job.Matrix.FlatJobMatrix {
@@ -551,6 +555,13 @@ func (gh *GHWorkflow) CompileGitHubWorkflow(o *ghworkflow.Output) error {
 
 		flatJobsAdded := false
 
+		// flatMatrixGateCondition, when non-empty, signals that this job is a
+		// flatJobMatrix whose label check should be applied as a gate step
+		// (inserted after the triggered workflow is generated) instead of as a
+		// job-level if, so the matrix always expands and per-entry check names
+		// resolve correctly.
+		var flatMatrixGateCondition string
+
 		if len(job.TriggerLabels) > 0 {
 			if len(job.Depends) < 1 {
 				return fmt.Errorf("job %s has triggerLabels but no depends", job.Name)
@@ -631,7 +642,17 @@ func (gh *GHWorkflow) CompileGitHubWorkflow(o *ghworkflow.Output) error {
 					return fmt.Sprintf("contains(fromJSON(needs.default.outputs.labels), '%s')", label)
 				})
 
-				jobDef.If = strings.Join(conditions, " || ")
+				ifCondition := strings.Join(conditions, " || ")
+
+				if job.Matrix != nil && job.Matrix.FlatJobMatrix {
+					// For flatJobMatrix, don't set jobDef.If — matrix must always
+					// expand so per-entry check names resolve. The label check is
+					// instead applied as a gate step (see below, after triggered
+					// workflow generation).
+					flatMatrixGateCondition = ifCondition
+				} else {
+					jobDef.If = ifCondition
+				}
 
 				if job.Matrix != nil && job.Matrix.FlatJobMatrix {
 					failFast := false
@@ -713,10 +734,9 @@ func (gh *GHWorkflow) CompileGitHubWorkflow(o *ghworkflow.Output) error {
 
 					triggeredJob.Name = strings.Join(parts, "-")
 				} else if len(job.Matrix.Include) > 0 {
-					for k := range job.Matrix.Include[0].Values {
-						triggeredJob.Name = "${{ matrix." + k + " }}"
-
-						break
+					keys := slices.Sorted(maps.Keys(job.Matrix.Include[0].Values))
+					if len(keys) > 0 {
+						triggeredJob.Name = "${{ matrix." + keys[0] + " }}"
 					}
 				}
 			}
@@ -774,6 +794,27 @@ func (gh *GHWorkflow) CompileGitHubWorkflow(o *ghworkflow.Output) error {
 					},
 				},
 			)
+		}
+
+		if flatMatrixGateCondition != "" {
+			const gateRef = "steps.check-pr-labels.conclusion == 'success'"
+
+			for _, step := range jobDef.Steps {
+				if step.If == "" {
+					step.If = gateRef
+				} else {
+					step.If = step.If + " && " + gateRef
+				}
+			}
+
+			gateStep := &ghworkflow.JobStep{
+				Name: "check-pr-labels",
+				ID:   "check-pr-labels",
+				If:   flatMatrixGateCondition,
+				Run:  "true",
+			}
+
+			jobDef.Steps = append([]*ghworkflow.JobStep{gateStep}, jobDef.Steps...)
 		}
 
 		if !job.CronOnly && !flatJobsAdded {

--- a/internal/project/common/repository.go
+++ b/internal/project/common/repository.go
@@ -42,8 +42,8 @@ type Repository struct { //nolint:govet
 	MainBranch string `yaml:"mainBranch"`
 
 	// DryRun, when true, logs the intended branch protection / conform changes
-	// instead of calling the GitHub API. Dry-run is also implicit when
-	// GITHUB_TOKEN is unset.
+	// instead of calling the GitHub API. Must be set explicitly; when
+	// GITHUB_TOKEN is unset, GitHub API integration is skipped entirely.
 	DryRun bool `yaml:"dryRun,omitempty"`
 
 	EnableConform             bool     `yaml:"enableConform"`
@@ -182,8 +182,9 @@ func (r *Repository) CompileLicense(o *license.Output) error {
 }
 
 // CompileGitHub implements github.Compiler. When Repository.DryRun is true,
-// changes are logged instead of applied. When GITHUB_TOKEN is unset and
-// DryRun is false, the step is skipped entirely.
+// intended changes are logged instead of applied. When the client is nil
+// (GITHUB_TOKEN unset) and DryRun is false, GitHub API integration is
+// skipped entirely.
 func (r *Repository) CompileGitHub(client *github.Client) error {
 	if client == nil && !r.DryRun {
 		return nil
@@ -297,11 +298,19 @@ func (r *Repository) enableLabels(client *github.Client) error {
 			continue
 		}
 
+		patch := &github.Label{}
+
 		if desc != "" && existing.GetDescription() != desc {
-			if _, _, err := client.Issues.EditLabel(context.Background(), r.meta.GitHubOrganization, r.meta.GitHubRepository, name, &github.Label{
-				Description: new(desc),
-			}); err != nil {
-				return fmt.Errorf("failed to update description for label %q: %w", name, err)
+			patch.Description = new(desc)
+		}
+
+		if existing.GetColor() != autoLabelColor {
+			patch.Color = new(autoLabelColor)
+		}
+
+		if patch.Description != nil || patch.Color != nil {
+			if _, _, err := client.Issues.EditLabel(context.Background(), r.meta.GitHubOrganization, r.meta.GitHubRepository, name, patch); err != nil {
+				return fmt.Errorf("failed to update label %q: %w", name, err)
 			}
 		}
 	}

--- a/internal/project/common/testdata/TestFlatJobMatrix/ci.yaml
+++ b/internal/project/common/testdata/TestFlatJobMatrix/ci.yaml
@@ -93,7 +93,7 @@ jobs:
       pull-requests: read
     runs-on:
       group: large
-    if: contains(fromJSON(needs.default.outputs.labels), 'integration/misc-0')
+    if: (!startsWith(github.head_ref, 'renovate/') && !startsWith(github.head_ref, 'dependabot/'))
     strategy:
       matrix:
         include:
@@ -109,11 +109,17 @@ jobs:
     needs:
       - default
     steps:
+      - name: check-pr-labels
+        id: check-pr-labels
+        if: contains(fromJSON(needs.default.outputs.labels), 'integration/misc-0')
+        run: "true"
       - name: gather-system-info
         id: system-info
+        if: steps.check-pr-labels.conclusion == 'success'
         uses: kenchan0130/actions-system-info@59699597e84e80085a750998045983daa49274c4 # version: v1.4.0
         continue-on-error: true
       - name: print-system-info
+        if: steps.check-pr-labels.conclusion == 'success'
         run: |
           MEMORY_GB=$((${{ steps.system-info.outputs.totalmem }}/1024/1024/1024))
 
@@ -135,11 +141,14 @@ jobs:
           done
         continue-on-error: true
       - name: checkout
+        if: steps.check-pr-labels.conclusion == 'success'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # version: v6.0.2
       - name: Unshallow
+        if: steps.check-pr-labels.conclusion == 'success'
         run: |
           git fetch --prune --unshallow
       - name: e2e-qemu
+        if: steps.check-pr-labels.conclusion == 'success'
         env:
           INTEGRATION_TEST_RUN: ${{ matrix.integrationTestRun }}
           SHORT_INTEGRATION_TEST: ${{ matrix.shortIntegrationTest }}

--- a/internal/project/helm/build.go
+++ b/internal/project/helm/build.go
@@ -91,8 +91,18 @@ func (helm *Build) CompileMakefile(output *makefile.Output) error {
 		Variable(makefile.OverridableVariable("COSIGN_ARGS", "")).
 		Variable(makefile.OverridableVariable("HELMDOCS_VERSION", config.HelmDocsVersion))
 
-	generateTarget := output.GetTarget("generate")
-	if generateTarget != nil {
+	var hasGenerate bool
+
+	for _, parent := range helm.Parents() {
+		if dag.FindByName("protobuf", parent.Inputs()...) != nil {
+			hasGenerate = true
+
+			break
+		}
+	}
+
+	if hasGenerate {
+		generateTarget := output.Target("generate")
 		generateTarget.Depends("helm-plugin-install")
 
 		// Only update Chart.yaml for final releases (vX.Y.Z, no pre-release suffix).


### PR DESCRIPTION
This PR fixes the following issues:

* for flatjob matrices when no labels were present the `if` condition gets evaluated first and matrix jobs are not defined, which could cause enforcing jobs to fail, fix by moving the check to a gated step and have other steps depend on it
* Fix deleting and creating labels, we only update
* Fix adding `generate` dependency on `check-dirty` if generate is not defined at all
* Address review comments from #639