### PR TITLE
feat: allow copying extra files into golang generator

### DIFF
--- a/internal/project/golang/generate.go
+++ b/internal/project/golang/generate.go
@@ -75,8 +75,9 @@ type ProtoSpec struct {
 
 // GoGenerateSpec describes a set of go generate specs to be compiled.
 type GoGenerateSpec struct {
-	Source string   `yaml:"source"`
-	Copy   []string `yaml:"copy"`
+	Source      string   `yaml:"source"`
+	ExtraInputs []string `yaml:"extraInputs"`
+	Copy        []string `yaml:"copy"`
 }
 
 // NewGenerate builds Generate node.
@@ -194,6 +195,12 @@ func (generate *Generate) ToolchainBuild(stage *dockerfile.Stage) error {
 func (generate *Generate) CompileDockerignore(output *dockerignore.Output) error {
 	if len(generate.GoGenerateSpecs) > 0 {
 		output.AllowLocalPath(license.Header)
+	}
+
+	for _, spec := range generate.GoGenerateSpecs {
+		for _, path := range spec.ExtraInputs {
+			output.AllowLocalPath(filepath.Clean(path))
+		}
 	}
 
 	return nil
@@ -345,11 +352,18 @@ func (generate *Generate) CompileDockerfile(output *dockerfile.Output) error {
 	}
 
 	for index, spec := range generate.GoGenerateSpecs {
-		output.Stage(fmt.Sprintf("go-generate-%d", index)).
+		stage := output.Stage(fmt.Sprintf("go-generate-%d", index)).
 			Description("run go generate").
 			From("base").
 			Step(step.WorkDir("/src")).
-			Step(step.Copy(license.Header, filepath.Join("./hack/", license.Header))).
+			Step(step.Copy(license.Header, filepath.Join("./hack/", license.Header)))
+
+		for _, path := range spec.ExtraInputs {
+			path = filepath.Clean(path)
+			stage.Step(step.Copy(path, path))
+		}
+
+		stage.
 			Step(step.Script(fmt.Sprintf("go generate %s/...", spec.Source)).
 				MountCache(filepath.Join(generate.meta.CachePath, "go-build"), generate.meta.GitHubRepository).
 				MountCache(filepath.Join(generate.meta.GoPath, "pkg"), generate.meta.GitHubRepository),

--- a/internal/project/golang/generate_test.go
+++ b/internal/project/golang/generate_test.go
@@ -1,0 +1,64 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package golang_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/kres/internal/output/dockerfile"
+	"github.com/siderolabs/kres/internal/output/dockerignore"
+	"github.com/siderolabs/kres/internal/project/golang"
+	"github.com/siderolabs/kres/internal/project/meta"
+)
+
+func TestGenerateExtraInputs(t *testing.T) {
+	generate := golang.NewGenerate(&meta.Options{
+		CachePath:        "/root/.cache",
+		CanonicalPaths:   []string{"github.com/siderolabs/example"},
+		GitHubRepository: "example",
+		GoPath:           "/go",
+	})
+
+	generate.GoGenerateSpecs = []golang.GoGenerateSpec{
+		{
+			Source: "./internal",
+			ExtraInputs: []string{
+				"./deploy/helm/omni/config-overrides.yaml",
+				"deploy/helm/omni/values.yaml",
+			},
+		},
+	}
+
+	var dockerfileOutput dockerfile.Output
+
+	require.NoError(t, generate.CompileDockerfile(&dockerfileOutput))
+
+	var dockerfileBuffer bytes.Buffer
+
+	require.NoError(t, dockerfileOutput.GenerateFile("Dockerfile", &dockerfileBuffer))
+
+	dockerfile := dockerfileBuffer.String()
+
+	require.Contains(t, dockerfile, "COPY deploy/helm/omni/config-overrides.yaml deploy/helm/omni/config-overrides.yaml\n")
+	require.Contains(t, dockerfile, "COPY deploy/helm/omni/values.yaml deploy/helm/omni/values.yaml\n")
+	require.Contains(t, dockerfile, "RUN --mount=type=cache,target=/root/.cache/go-build,id=example/root/.cache/go-build "+
+		"--mount=type=cache,target=/go/pkg,id=example/go/pkg go generate ./internal/...\n")
+
+	dockerignoreOutput := dockerignore.NewOutput()
+
+	require.NoError(t, generate.CompileDockerignore(dockerignoreOutput))
+
+	var dockerignoreBuffer bytes.Buffer
+
+	require.NoError(t, dockerignoreOutput.GenerateFile(".dockerignore", &dockerignoreBuffer))
+
+	dockerignore := dockerignoreBuffer.String()
+
+	require.Contains(t, dockerignore, "!deploy/helm/omni/config-overrides.yaml\n")
+	require.Contains(t, dockerignore, "!deploy/helm/omni/values.yaml\n")
+}


### PR DESCRIPTION
Add ability to copy extra files into the `go-generate-*` build containers, so that `//go:generate` directives can read files from paths which are not in `source`, e.g., as inputs.