### PR TITLE
fix: generating job labels

### DIFF
--- a/internal/output/ghworkflow/gh_workflow.go
+++ b/internal/output/ghworkflow/gh_workflow.go
@@ -807,6 +807,17 @@ func (step *JobStep) SetConditions(conditions ...string) error {
 			continue
 		}
 
+		if expr, ok := strings.CutPrefix(condition, "raw:"); ok {
+			expr = strings.TrimSpace(expr)
+			if expr == "" {
+				return fmt.Errorf("raw condition expression must not be empty")
+			}
+
+			step.appendIf(expr)
+
+			continue
+		}
+
 		switch condition {
 		case "except-pull-request":
 			step.appendIf("github.event_name != 'pull_request'")
@@ -846,10 +857,30 @@ func (job *Job) appendIf(condition string) {
 }
 
 // SetConditions sets job conditions.
+//
+// In addition to the named keyword conditions (e.g. "on-pull-request",
+// "only-on-tag"), a condition prefixed with "raw:" is appended verbatim as
+// a GitHub Actions expression. Use this to gate a job on workflow-runtime
+// state for which there is no dedicated keyword — for example:
+//
+//	conditions:
+//	  - on-pull-request
+//	  - "raw:startsWith(github.event.pull_request.title, 'release(')"
 func (job *Job) SetConditions(conditions ...string) error {
 	for _, condition := range conditions {
 		if strings.HasPrefix(condition, "matrix.") {
 			job.appendIf(fmt.Sprintf("${{ %s }}", condition))
+
+			continue
+		}
+
+		if expr, ok := strings.CutPrefix(condition, "raw:"); ok {
+			expr = strings.TrimSpace(expr)
+			if expr == "" {
+				return fmt.Errorf("raw condition expression must not be empty")
+			}
+
+			job.appendIf(expr)
 
 			continue
 		}

--- a/internal/output/ghworkflow/gh_workflow_test.go
+++ b/internal/output/ghworkflow/gh_workflow_test.go
@@ -103,6 +103,61 @@ func TestSetConditionsNotCancelled(t *testing.T) {
 	}
 }
 
+func TestSetConditionsRaw(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		wantIf     string
+		wantErr    string
+		conditions []string
+	}{
+		{
+			name:       "raw alone",
+			conditions: []string{"raw:startsWith(github.event.pull_request.title, 'release(')"},
+			wantIf:     "startsWith(github.event.pull_request.title, 'release(')",
+		},
+		{
+			name:       "raw combined with keyword",
+			conditions: []string{"on-pull-request", "raw:github.actor != 'dependabot[bot]'"},
+			wantIf:     "github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'",
+		},
+		{
+			name:       "raw expression is trimmed",
+			conditions: []string{"raw:   github.actor != 'bot'   "},
+			wantIf:     "github.actor != 'bot'",
+		},
+		{
+			name:       "empty raw expression rejected",
+			conditions: []string{"raw:"},
+			wantErr:    "raw condition expression must not be empty",
+		},
+		{
+			name:       "whitespace-only raw expression rejected",
+			conditions: []string{"raw:    "},
+			wantErr:    "raw condition expression must not be empty",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			job := &ghworkflow.Job{}
+			step := ghworkflow.Step("test")
+
+			jobErr := job.SetConditions(tc.conditions...)
+			stepErr := step.SetConditions(tc.conditions...)
+
+			if tc.wantErr != "" {
+				require.EqualError(t, jobErr, tc.wantErr)
+				require.EqualError(t, stepErr, tc.wantErr)
+
+				return
+			}
+
+			require.NoError(t, jobErr)
+			require.NoError(t, stepErr)
+			assert.Equal(t, tc.wantIf, job.If)
+			assert.Equal(t, tc.wantIf, step.If)
+		})
+	}
+}
+
 func TestMatrixStrategy(t *testing.T) {
 	output.PreambleTimestamp, _ = time.Parse(time.RFC3339, strings.ReplaceAll(time.RFC3339, "07:00", "")) //nolint:errcheck
 	output.PreambleCreator = "test"

--- a/internal/project/common/gh_workflow.go
+++ b/internal/project/common/gh_workflow.go
@@ -219,10 +219,13 @@ func (gh *GHWorkflow) CollectEnforceContexts() []string {
 }
 
 // CollectTriggerLabels returns the deduplicated set of PR labels referenced as
-// job-level TriggerLabels or per-entry matrix TriggerLabels, mapped to their
-// description (taken from GHWorkflow.LabelDescriptions; empty string if none).
-// The result is suitable for provisioning the corresponding labels on the
-// GitHub repository.
+// job-level TriggerLabels, per-entry matrix TriggerLabels, and per-entry
+// auto-derived labels for label-triggered non-FlatJobMatrix matrices (which the
+// workflow renderer emits at CompileGitHubWorkflow time; see the entryLabel
+// computation inside the flat-job expansion branch). Each label is mapped to
+// its description from GHWorkflow.LabelDescriptions (empty string if none). The
+// result is suitable for provisioning the corresponding labels on the GitHub
+// repository.
 func (gh *GHWorkflow) CollectTriggerLabels() map[string]string {
 	labels := map[string]string{}
 
@@ -238,6 +241,38 @@ func (gh *GHWorkflow) CollectTriggerLabels() map[string]string {
 		for _, entry := range job.Matrix.Include {
 			for _, l := range entry.TriggerLabels {
 				labels[l] = gh.LabelDescriptions[l]
+			}
+		}
+
+		// Only label-triggered, non-flat matrices with LabelKeys undergo the
+		// flat-job expansion in CompileGitHubWorkflow that derives per-entry
+		// labels; gating on the same conditions here avoids provisioning
+		// labels that no generated workflow ever references.
+		if len(job.TriggerLabels) == 0 || len(job.Matrix.LabelKeys) == 0 || job.Matrix.FlatJobMatrix {
+			continue
+		}
+
+		// Mirror the per-entry label derivation done by the flat-job
+		// expansion in CompileGitHubWorkflow so these labels exist on the
+		// GitHub repository (otherwise users can't apply them to a PR to
+		// trigger a specific matrix entry). The derivation must match the
+		// renderer exactly — including entries where no LabelKeys resolve to
+		// a value (yielding a flatJobName with a trailing "-") — so the
+		// provisioned labels never drift from the generated conditions.
+		for _, entry := range job.Matrix.Include {
+			parts := make([]string, 0, len(job.Matrix.LabelKeys))
+
+			for _, k := range job.Matrix.LabelKeys {
+				if v := entry.Values[k]; v != "" {
+					parts = append(parts, v)
+				}
+			}
+
+			flatJobName := job.Name + "-" + strings.Join(parts, "-")
+			entryLabel := "integration/" + strings.TrimPrefix(flatJobName, "integration-")
+
+			if _, ok := labels[entryLabel]; !ok {
+				labels[entryLabel] = gh.LabelDescriptions[entryLabel]
 			}
 		}
 	}

--- a/internal/project/common/gh_workflow_test.go
+++ b/internal/project/common/gh_workflow_test.go
@@ -321,6 +321,127 @@ func TestFlatJobMatrix(t *testing.T) {
 	assertGolden(t, "ci.yaml", buf.Bytes())
 }
 
+// TestCollectTriggerLabels verifies that CollectTriggerLabels gathers job-level
+// and per-entry matrix TriggerLabels, and auto-derives per-entry labels for
+// label-triggered non-flat matrices exactly as the flat-job expansion in
+// CompileGitHubWorkflow does — while leaving non-triggered and flat matrices
+// alone.
+func TestCollectTriggerLabels(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		labelDescriptions map[string]string
+		want              map[string]string
+		jobs              []common.Job
+	}{
+		{
+			name: "job-level and per-entry trigger labels",
+			labelDescriptions: map[string]string{
+				"integration/qemu": "run qemu tests",
+			},
+			jobs: []common.Job{
+				{
+					Name:          "integration-qemu",
+					TriggerLabels: []string{"integration/qemu"},
+					Matrix: &common.Matrix{
+						Include: []common.MatrixInclude{
+							{
+								Values:        common.MatrixEntry{"variant": "default"},
+								TriggerLabels: []string{"integration/qemu-default"},
+							},
+						},
+					},
+				},
+			},
+			want: map[string]string{
+				"integration/qemu":         "run qemu tests",
+				"integration/qemu-default": "",
+			},
+		},
+		{
+			name: "derives per-entry labels for label-triggered non-flat matrix",
+			jobs: []common.Job{
+				{
+					Name:          "integration-aws-nvidia",
+					TriggerLabels: []string{"integration/aws-nvidia"},
+					Matrix: &common.Matrix{
+						LabelKeys: []string{"driver", "variant"},
+						Include: []common.MatrixInclude{
+							{Values: common.MatrixEntry{"driver": "oss", "variant": "lts"}},
+							{Values: common.MatrixEntry{"driver": "nonfree", "variant": "lts"}},
+						},
+					},
+				},
+			},
+			want: map[string]string{
+				"integration/aws-nvidia":             "",
+				"integration/aws-nvidia-oss-lts":     "",
+				"integration/aws-nvidia-nonfree-lts": "",
+			},
+		},
+		{
+			name: "no derivation for matrix without trigger labels",
+			jobs: []common.Job{
+				{
+					Name: "integration-aws-nvidia",
+					Matrix: &common.Matrix{
+						LabelKeys: []string{"driver"},
+						Include: []common.MatrixInclude{
+							{Values: common.MatrixEntry{"driver": "oss"}},
+						},
+					},
+				},
+			},
+			want: map[string]string{},
+		},
+		{
+			name: "no derivation for flat job matrix",
+			jobs: []common.Job{
+				{
+					Name:          "integration-misc-0",
+					TriggerLabels: []string{"integration/misc-0"},
+					Matrix: &common.Matrix{
+						FlatJobMatrix: true,
+						LabelKeys:     []string{"test"},
+						Include: []common.MatrixInclude{
+							{Values: common.MatrixEntry{"test": "e2e-firewall"}},
+						},
+					},
+				},
+			},
+			want: map[string]string{
+				"integration/misc-0": "",
+			},
+		},
+		{
+			name: "entry with no resolving label keys derives trailing-dash label",
+			jobs: []common.Job{
+				{
+					Name:          "integration-aws-nvidia",
+					TriggerLabels: []string{"integration/aws-nvidia"},
+					Matrix: &common.Matrix{
+						LabelKeys: []string{"driver"},
+						Include: []common.MatrixInclude{
+							{Values: common.MatrixEntry{"arch": "amd64"}},
+						},
+					},
+				},
+			},
+			want: map[string]string{
+				"integration/aws-nvidia":  "",
+				"integration/aws-nvidia-": "",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			gw := common.NewGHWorkflow(&meta.Options{})
+			gw.Jobs = tc.jobs
+			gw.LabelDescriptions = tc.labelDescriptions
+
+			assert.Equal(t, tc.want, gw.CollectTriggerLabels())
+		})
+	}
+}
+
 // TestMatrixPerEntryTriggerLabels verifies that per-entry TriggerLabels fire only
 // the matching flat job, while job-level TriggerLabels fire all flat jobs.
 // This tests the combined oss/nonfree scenario where integration/aws-nvidia-oss must


### PR DESCRIPTION
interpolate inner job names too for labels.
Also support defining `raw` if conditions.