### PR TITLE
fix: `generate` also depends on `generate-*` targets

### DIFF
--- a/internal/project/js/protobuf.go
+++ b/internal/project/js/protobuf.go
@@ -76,9 +76,14 @@ func (proto *Protobuf) CompileMakefile(output *makefile.Output) error {
 		return nil
 	}
 
-	output.Target("generate-" + proto.Name()).
+	targetName := "generate-" + proto.Name()
+	output.Target(targetName).
 		Description("Generate .proto definitions.").
 		Script("@$(MAKE) local-$@ DEST=./")
+
+	if output.HasTarget("generate") {
+		output.Target("generate").Depends(targetName)
+	}
 
 	return nil
 }
@@ -194,7 +199,9 @@ func (proto *Protobuf) CompileLefthook(output *lefthook.Output) error {
 	output.Hook(lefthook.HookGroupPreCommit).
 		Group(lefthook.PreCommitFixStage).
 		WithParallel(false).
-		Job().WithName("generate " + proto.Name()).WithRun("make generate-" + proto.Name()).WithStageFixed()
+		Job().
+		WithName("generate " + proto.Name()).
+		WithRun("make generate-" + proto.Name()).WithStageFixed()
 
 	return nil
 }

--- a/internal/project/js/protobuf_test.go
+++ b/internal/project/js/protobuf_test.go
@@ -24,6 +24,51 @@ func TestProtobufInterfaces(t *testing.T) {
 	assert.Implements(t, (*lefthook.Compiler)(nil), new(js.Protobuf))
 }
 
+func TestProtobufMakefileGenerateDepends(t *testing.T) {
+	for _, tt := range []struct {
+		name               string
+		registerCheckDirty bool
+		wantDepends        bool
+	}{
+		{
+			name:               "generate target depends on generate-frontend",
+			registerCheckDirty: true,
+			wantDepends:        true,
+		},
+		{
+			name:               "no generate target leaves generate-frontend orphan",
+			registerCheckDirty: false,
+			wantDepends:        false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			proto := js.NewProtobuf(&meta.Options{}, "frontend")
+			proto.Specs = []js.ProtoSpec{{Source: "api.proto"}}
+
+			output := makefile.NewOutput()
+
+			if tt.registerCheckDirty {
+				output.Target("generate")
+			}
+
+			require.NoError(t, proto.CompileMakefile(output))
+
+			var buf bytes.Buffer
+
+			require.NoError(t, output.GenerateFile("Makefile", &buf))
+
+			rendered := buf.String()
+			assert.Contains(t, rendered, "generate-frontend:")
+
+			if tt.wantDepends {
+				assert.Contains(t, rendered, "generate: generate-frontend")
+			} else {
+				assert.NotContains(t, rendered, "generate:")
+			}
+		})
+	}
+}
+
 func TestProtobufLefthook(t *testing.T) {
 	proto := js.NewProtobuf(&meta.Options{}, "frontend")
 


### PR DESCRIPTION
Resolves https://github.com/siderolabs/kres/issues/664

- The `generate` didn't depend on the additional `generate-*` targets, which made it incomplete for some repositories (e.g. Omni). Since `check-dirty` uses the `generate` target to check for stale artifacts, this lead to stale `generate-frontend` outputs in Omni, as `check-dirty` didn't catch it ([link](https://github.com/siderolabs/omni/pull/2921/changes/BASE..015c9cb4999f8a732ea6aff7e8493c9edf215ef9#diff-48bbd0b6353c258a960c885df4ab015e04ad3bc16ff8287cf43346f091180372R305)).
- Kres' own generated configs are up to date without any diff, since Kres doesn't have additional `generate-*` targets.