### PR TITLE
feat: enrich SBOM with license information

### DIFF
--- a/internal/project/golang/sbom.go
+++ b/internal/project/golang/sbom.go
@@ -108,9 +108,12 @@ func (sbom *SBOM) CompileDockerfile(output *dockerfile.Output) error {
 		Step(step.WorkDir("/src")).
 		Step(
 			step.Script(fmt.Sprintf(
-				`SYFT_FORMAT_PRETTY=1 SYFT_FORMAT_SPDX_JSON_DETERMINISTIC_UUID=1 syft scan dir:/src --source-name %s --source-version "${TAG}" -o spdx-json=/%s -o cyclonedx-json=/%s`,
-				sbom.sourceName(), sbomSPDXFile, sbomCycloneDXFile,
-			)),
+				`SYFT_FORMAT_PRETTY=1 SYFT_FORMAT_SPDX_JSON_DETERMINISTIC_UUID=1 SYFT_GOLANG_SEARCH_LOCAL_MOD_CACHE_LICENSES=1 SYFT_GOLANG_LOCAL_MOD_CACHE_DIR=%s `+
+					`syft scan dir:/src --source-name %s --source-version "${TAG}" -o spdx-json=/%s -o cyclonedx-json=/%s`,
+				filepath.Join(sbom.meta.GoPath, "pkg", "mod"), sbom.sourceName(), sbomSPDXFile, sbomCycloneDXFile,
+			)).
+				MountCache(filepath.Join(sbom.meta.CachePath, "go-build"), sbom.meta.GitHubRepository).
+				MountCache(filepath.Join(sbom.meta.GoPath, "pkg"), sbom.meta.GitHubRepository),
 		)
 
 	output.Stage("sbom").


### PR DESCRIPTION
Make Syft reflect license information via Go module cache.