### PR TITLE
fix: report all golangci-lint issues at once

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -146,8 +146,8 @@ linters:
       - builtin$
       - examples$
 issues:
-  max-issues-per-linter: 10
-  max-same-issues: 3
+  max-issues-per-linter: 1024
+  max-same-issues: 1024
   uniq-by-line: true
   new: false
 

--- a/internal/output/golangci/golangci.yml
+++ b/internal/output/golangci/golangci.yml
@@ -128,8 +128,8 @@ linters:
       - builtin$
       - examples$
 issues:
-  max-issues-per-linter: 10
-  max-same-issues: 3
+  max-issues-per-linter: 1024
+  max-same-issues: 1024
   uniq-by-line: true
   new: false
 


### PR DESCRIPTION
The generated golangci-lint config capped reported issues low enough that lint runs only surfaced a handful of problems at a time. Fixing those and rerunning would then reveal the next batch, forcing several round trips through the same cleanup.

Raise the per-linter and same-issue reporting limits so a single run reports effectively everything. These limits only filter already-produced findings, so analysis and CI runtime are unaffected.