### PR TITLE
chore: enable lefthook regardless of `CompileGithubWorkflowsOnly`

### DIFF
--- a/cmd/kres/cmd/gen.go
+++ b/cmd/kres/cmd/gen.go
@@ -77,6 +77,7 @@ func runGen() error {
 		output.Wrap(sops.NewOutput()),
 		output.Wrap(renovate.NewOutput()),
 		output.Wrap(conform.NewOutput()),
+		output.Wrap(lefthook.NewOutput()),
 	}
 
 	if !options.CompileGithubWorkflowsOnly {
@@ -92,7 +93,6 @@ func runGen() error {
 			output.Wrap(release.NewOutput()),
 			output.Wrap(markdownlint.NewOutput()),
 			output.Wrap(template.NewOutput()),
-			output.Wrap(lefthook.NewOutput()),
 		)
 	}
 


### PR DESCRIPTION
Currently the Lefthook output will be compiled only when `CompileGithubWorkflowsOnly` is false. We actually want to generate the `lefthook.yml` always, regardless of the GH workflow flag.

`make rekres` creates zero-diff.

This still won't generate a meaningful config for Talos, but that's a separate problem. 