### PR TITLE
chore: revert "chore: allow lefthook when `CompileGitHubWorkflowsOnly`"

### DIFF
--- a/cmd/kres/cmd/gen.go
+++ b/cmd/kres/cmd/gen.go
@@ -77,7 +77,6 @@ func runGen() error {
 		output.Wrap(sops.NewOutput()),
 		output.Wrap(renovate.NewOutput()),
 		output.Wrap(conform.NewOutput()),
-		output.Wrap(lefthook.NewOutput()),
 	}
 
 	if !options.CompileGithubWorkflowsOnly {
@@ -93,6 +92,7 @@ func runGen() error {
 			output.Wrap(release.NewOutput()),
 			output.Wrap(markdownlint.NewOutput()),
 			output.Wrap(template.NewOutput()),
+			output.Wrap(lefthook.NewOutput()),
 		)
 	}
 


### PR DESCRIPTION
This reverts commit d98557c5efd2cd95f1a2e1a90eafbb4cb31f0fe8.

Turns out the Talos-side configuration is way more blocking for having auto-generated `lefthook.yml` than I anticipated. The Makefile/golang outputs are not generated for Talos, they're hand-written and maintained. Therefore, the `CompileLefthook` callables attached to these outputs never execute, leading to an effectively empty lefthook.yml (just an empty JSON document `{}`).

For the time being, it's far more viable to manually add a lefthook config for Talos. Having that config generated for "GH workflow only" would wipe the lefthook.yml on every `make rekres`. Therefore, we need to revert this change.