### PR TITLE
feat: allow to disable cross-arch builder

### DIFF
--- a/internal/output/ghworkflow/gh_workflow.go
+++ b/internal/output/ghworkflow/gh_workflow.go
@@ -532,10 +532,10 @@ func (o *Output) SetRunnerGroup(runner string) {
 
 // SetOptionsForPkgs overwrites default job steps and services for pkgs.
 // Note that calling this method will overwrite any existing steps.
-func (o *Output) SetOptionsForPkgs() {
+func (o *Output) SetOptionsForPkgs(enableCrossBuilder bool) {
 	o.SetRunnerGroup(PkgsRunner)
 
-	o.workflows[CiWorkflow].Jobs[DefaultJobName].Steps = DefaultPkgsSteps()
+	o.workflows[CiWorkflow].Jobs[DefaultJobName].Steps = DefaultPkgsSteps(enableCrossBuilder)
 }
 
 // SetWorkflowOn sets the workflow on event.
@@ -600,7 +600,16 @@ func DefaultSteps() []*JobStep {
 }
 
 // DefaultPkgsSteps returns default pkgs steps for the workflow.
-func DefaultPkgsSteps() []*JobStep {
+func DefaultPkgsSteps(withCrossBuilder bool) []*JobStep {
+	withMap := map[string]string{
+		"driver":   "remote",
+		"endpoint": "tcp://buildkit-amd64.ci.svc.cluster.local:1234",
+	}
+
+	if withCrossBuilder {
+		withMap["append"] = strings.TrimPrefix(armbuildkitdEnpointConfig, "\n")
+	}
+
 	return append(
 		CommonSteps(),
 		&JobStep{
@@ -610,11 +619,7 @@ func DefaultPkgsSteps() []*JobStep {
 				Image:   "docker/setup-buildx-action@" + config.SetupBuildxActionRef,
 				Comment: "version: " + config.SetupBuildxActionVersion,
 			},
-			With: map[string]string{
-				"driver":   "remote",
-				"endpoint": "tcp://buildkit-amd64.ci.svc.cluster.local:1234",
-				"append":   strings.TrimPrefix(armbuildkitdEnpointConfig, "\n"),
-			},
+			With: withMap,
 		},
 	)
 }

--- a/internal/project/common/gh_workflow.go
+++ b/internal/project/common/gh_workflow.go
@@ -315,7 +315,7 @@ func (gh *GHWorkflow) CompileGitHubWorkflow(o *ghworkflow.Output) error {
 			jobDef.Steps = ghworkflow.DefaultSteps()
 
 			if job.BuildxOptions.CrossBuilder {
-				jobDef.Steps = ghworkflow.DefaultPkgsSteps()
+				jobDef.Steps = ghworkflow.DefaultPkgsSteps(true)
 			}
 		}
 

--- a/internal/project/pkgfile/build.go
+++ b/internal/project/pkgfile/build.go
@@ -41,6 +41,7 @@ type Build struct {
 		} `yaml:"extraVariables"`
 	} `yaml:"makefile"`
 	UseBldrPkgTagResolver bool `yaml:"useBldrPkgTagResolver"`
+	DisableCrossBuilder   bool `yaml:"disableCrossBuilder"`
 }
 
 var (
@@ -204,7 +205,7 @@ func (pkgfile *Build) CompileMakefile(output *makefile.Output) error {
 
 // CompileGitHubWorkflow implements ghworkflow.Compiler.
 func (pkgfile *Build) CompileGitHubWorkflow(output *ghworkflow.Output) error {
-	output.SetOptionsForPkgs()
+	output.SetOptionsForPkgs(!pkgfile.DisableCrossBuilder)
 
 	loginStep := ghworkflow.Step("Login to registry").
 		SetUsesWithComment(
@@ -288,7 +289,7 @@ func (pkgfile *Build) CompileGitHubWorkflow(output *ghworkflow.Output) error {
 			RunsOn: ghworkflow.NewRunsOnGroupLabel(ghworkflow.PkgsRunner, ""),
 			If:     "contains(fromJSON(needs.default.outputs.labels || '[]'), 'integration/reproducibility')",
 			Needs:  []string{ghworkflow.DefaultJobName},
-			Steps:  ghworkflow.DefaultPkgsSteps(),
+			Steps:  ghworkflow.DefaultPkgsSteps(!pkgfile.DisableCrossBuilder),
 		}, nil)
 		output.AddStep("reproducibility", ghworkflow.Step("reproducibility-test").SetMakeStep("reproducibility-test"))
 
@@ -313,7 +314,7 @@ func (pkgfile *Build) CompileGitHubWorkflow(output *ghworkflow.Output) error {
 					"reproducibility": {
 						RunsOn: ghworkflow.NewRunsOnGroupLabel(ghworkflow.PkgsRunner, ""),
 						Steps: append(
-							ghworkflow.DefaultPkgsSteps(),
+							ghworkflow.DefaultPkgsSteps(!pkgfile.DisableCrossBuilder),
 							ghworkflow.Step("reproducibility-test").SetMakeStep("reproducibility-test"),
 						),
 					},


### PR DESCRIPTION
This is needed for tools-rust to stay on amd64 builder only (due to StageX rust being amd64 only).