### PR TITLE
feat: support pinning `bldr` version

### DIFF
--- a/internal/project/pkgfile/build.go
+++ b/internal/project/pkgfile/build.go
@@ -26,14 +26,13 @@ const (
 
 // Build provides common pkgfile build environment settings.
 type Build struct {
+	meta              *meta.Options
+	AdditionalTargets map[string][]string `yaml:"additionalTargets"`
 	dag.BaseNode
-
-	meta *meta.Options
-
-	ReproducibleTargetName string              `yaml:"reproducibleTargetName"`
-	AdditionalTargets      map[string][]string `yaml:"additionalTargets"`
-	Targets                []string            `yaml:"targets"`
-	ExtraBuildArgs         []string            `yaml:"extraBuildArgs"`
+	ReproducibleTargetName string   `yaml:"reproducibleTargetName"`
+	BldrImageVersion       string   `yaml:"bldrImageVersion"`
+	Targets                []string `yaml:"targets"`
+	ExtraBuildArgs         []string `yaml:"extraBuildArgs"`
 	Makefile               struct {
 		ExtraVariables []struct {
 			Name         string `yaml:"name"`
@@ -65,6 +64,8 @@ func NewBuild(meta *meta.Options) *Build {
 	return &Build{
 		meta: meta,
 
+		BldrImageVersion: config.BldrImageVersion,
+
 		BaseNode: dag.NewBaseNode("pkgfile"),
 	}
 }
@@ -83,7 +84,7 @@ func (pkgfile *Build) CompileMakefile(output *makefile.Output) error {
 		Variable(makefile.SimpleVariable("SOURCE_DATE_EPOCH", "$(shell git log $(INITIAL_COMMIT_SHA) --pretty=%ct)"))
 
 	output.VariableGroup("sync bldr image with pkgfile").
-		Variable(makefile.SimpleVariable("BLDR_RELEASE", config.BldrImageVersion)).
+		Variable(makefile.SimpleVariable("BLDR_RELEASE", pkgfile.BldrImageVersion)).
 		Variable(makefile.SimpleVariable("BLDR_IMAGE", "ghcr.io/siderolabs/bldr:$(BLDR_RELEASE)")).
 		Variable(makefile.SimpleVariable("BLDR", "docker run --rm --user $(shell id -u):$(shell id -g) --volume $(PWD):/src --entrypoint=/bldr $(BLDR_IMAGE) --root=/src"))
 

--- a/internal/project/pkgfile/build_test.go
+++ b/internal/project/pkgfile/build_test.go
@@ -1,0 +1,67 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package pkgfile_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/kres/internal/config"
+	"github.com/siderolabs/kres/internal/output/makefile"
+	"github.com/siderolabs/kres/internal/project/meta"
+	"github.com/siderolabs/kres/internal/project/pkgfile"
+)
+
+func TestBuildInterfaces(t *testing.T) {
+	assert.Implements(t, (*makefile.Compiler)(nil), new(pkgfile.Build))
+}
+
+// TestNewBuildDefaultsBldrImageVersion verifies the node defaults the bldr
+// version to the package constant when nothing overrides it.
+func TestNewBuildDefaultsBldrImageVersion(t *testing.T) {
+	build := pkgfile.NewBuild(&meta.Options{})
+
+	assert.Equal(t, config.BldrImageVersion, build.BldrImageVersion)
+}
+
+func compileMakefile(t *testing.T, build *pkgfile.Build) string {
+	t.Helper()
+
+	o := makefile.NewOutput()
+
+	require.NoError(t, o.Compile(build))
+
+	var buf bytes.Buffer
+
+	require.NoError(t, o.GenerateFile("Makefile", &buf))
+
+	return buf.String()
+}
+
+// TestCompileMakefileDefaultBldrRelease verifies the generated Makefile pins
+// BLDR_RELEASE to the default constant when the version is not overridden.
+func TestCompileMakefileDefaultBldrRelease(t *testing.T) {
+	build := pkgfile.NewBuild(&meta.Options{})
+
+	out := compileMakefile(t, build)
+
+	assert.Contains(t, out, "BLDR_RELEASE := "+config.BldrImageVersion)
+	assert.Contains(t, out, "BLDR_IMAGE := ghcr.io/siderolabs/bldr:$(BLDR_RELEASE)")
+}
+
+// TestCompileMakefilePinnedBldrRelease verifies a pinned bldr version (as set
+// from .kres.yaml) flows into the generated BLDR_RELEASE variable.
+func TestCompileMakefilePinnedBldrRelease(t *testing.T) {
+	build := pkgfile.NewBuild(&meta.Options{})
+	build.BldrImageVersion = "v0.5.0"
+
+	out := compileMakefile(t, build)
+
+	assert.Contains(t, out, "BLDR_RELEASE := v0.5.0")
+	assert.NotContains(t, out, "BLDR_RELEASE := "+config.BldrImageVersion)
+}


### PR DESCRIPTION
Resolves https://github.com/siderolabs/kres/issues/681

Adds support for pinning the `bldr` image version in Kres-generated files. This makes for easier `make rekres` while maintaining the original `bldr` version in non-latest release branches (e.g. Talos 1.12)