### PR TITLE
feat: add --strict-allow-scripts to npm ci

### DIFF
--- a/internal/project/js/chromatic.go
+++ b/internal/project/js/chromatic.go
@@ -57,7 +57,7 @@ func (c *Chromatic) CompileGitHubWorkflow(o *ghworkflow.Output) error {
 
 	installStep := &ghworkflow.JobStep{
 		Name:             "Install dependencies",
-		Run:              "npm ci\n",
+		Run:              "npm ci --strict-allow-scripts\n",
 		WorkingDirectory: "frontend/",
 	}
 


### PR DESCRIPTION
Add [--strict-allow-scripts](https://docs.npmjs.com/cli/v11/commands/npm-approve-scripts) to npm ci to force the manual approval of npm package scripts rather than automatically running whatever it finds.

It will become the default with npm v12 but we can opt-in today already.