### PR TITLE
feat: allow providing source assets from container images

### DIFF
--- a/internal/output/dockerignore/dockerignore.go
+++ b/internal/output/dockerignore/dockerignore.go
@@ -21,6 +21,7 @@ type Output struct {
 	output.FileAdapter
 
 	allowedLocalPaths []string
+	deniedLocalPaths  []string
 }
 
 // NewOutput creates new dockerignore output.
@@ -49,6 +50,14 @@ func (o *Output) AllowLocalPath(paths ...string) *Output {
 	return o
 }
 
+// DenyLocalPath excludes path from the context even when it is inside an allowed path, since the
+// deny rules are written after the allow rules.
+func (o *Output) DenyLocalPath(paths ...string) *Output {
+	o.deniedLocalPaths = append(o.deniedLocalPaths, paths...)
+
+	return o
+}
+
 // GenerateFile implements output.FileWriter interface.
 func (o *Output) GenerateFile(filename string, w io.Writer) error {
 	switch filename {
@@ -70,6 +79,12 @@ func (o *Output) dockerignore(w io.Writer) error {
 
 	for _, path := range o.allowedLocalPaths {
 		if _, err := fmt.Fprintf(w, "!%s\n", path); err != nil {
+			return err
+		}
+	}
+
+	for _, path := range o.deniedLocalPaths {
+		if _, err := fmt.Fprintln(w, path); err != nil {
 			return err
 		}
 	}

--- a/internal/project/auto/golang.go
+++ b/internal/project/auto/golang.go
@@ -226,6 +226,18 @@ func (builder *builder) BuildGolang() error {
 	toolchain := golang.NewToolchain(builder.meta)
 	toolchain.AddInput(builder.commonInputs...)
 
+	// source assets are consumed by the golang base stage, so they are only wired for Go projects
+	if builder.meta.Config != nil {
+		sourceAssets := common.NewSourceAssets(builder.meta)
+		if err := builder.meta.Config.Load(sourceAssets); err != nil {
+			return err
+		}
+
+		if len(sourceAssets.Images) > 0 {
+			toolchain.AddInput(sourceAssets)
+		}
+	}
+
 	// add protobufs and go generate
 	generate := golang.NewGenerate(builder.meta)
 

--- a/internal/project/common/source_assets.go
+++ b/internal/project/common/source_assets.go
@@ -1,0 +1,215 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package common
+
+import (
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/siderolabs/gen/xslices"
+
+	"github.com/siderolabs/kres/internal/dag"
+	"github.com/siderolabs/kres/internal/output/dockerfile"
+	"github.com/siderolabs/kres/internal/output/dockerfile/step"
+	"github.com/siderolabs/kres/internal/output/dockerignore"
+	"github.com/siderolabs/kres/internal/output/gitignore"
+	"github.com/siderolabs/kres/internal/output/makefile"
+	"github.com/siderolabs/kres/internal/output/renovate"
+	"github.com/siderolabs/kres/internal/project/meta"
+)
+
+// SourceAssetsStage is the name of the docker stage which collects all the source assets.
+const SourceAssetsStage = "source-assets"
+
+// SourceAssets provides files materialized into the source tree of the build without being committed
+// to the repository, e.g. binaries referenced by go:embed directives.
+//
+// The files are pulled from pinned container images. The docker build copies them from image stages
+// into the source tree of the base stage, so every stage built on top of it sees them. For native
+// builds outside docker, a generated make target fetches the same files through the same stages, so
+// the two paths cannot diverge. The destinations are ignored in git and excluded from the docker
+// build context.
+//
+// Only Go projects consume the assets, and only one document of this kind is honored per project.
+// The generated docker stage names use the "source-assets" prefix, which no other stage should use.
+type SourceAssets struct { //nolint:govet
+	dag.BaseNode
+
+	meta *meta.Options
+
+	Images []SourceAssetsImage `yaml:"images"`
+}
+
+// SourceAssetsImage is a pinned container image providing source assets.
+type SourceAssetsImage struct {
+	Ref    string             `yaml:"ref"`
+	Copies []SourceAssetsCopy `yaml:"copies"`
+}
+
+// SourceAssetsCopy is a single path copied out of an image into the source tree.
+type SourceAssetsCopy struct {
+	Platform    string `yaml:"platform"`
+	Source      string `yaml:"source"`
+	Destination string `yaml:"destination"`
+}
+
+// NewSourceAssets initializes SourceAssets.
+func NewSourceAssets(meta *meta.Options) *SourceAssets {
+	return &SourceAssets{
+		BaseNode: dag.NewBaseNode(SourceAssetsStage),
+		meta:     meta,
+	}
+}
+
+// AfterLoad validates and normalizes the configuration.
+func (assets *SourceAssets) AfterLoad() error {
+	var destinations []string
+
+	for i, image := range assets.Images {
+		if image.Ref == "" {
+			return fmt.Errorf("source assets image ref is empty")
+		}
+
+		if len(image.Copies) == 0 {
+			return fmt.Errorf("source assets image %q declares no copies", image.Ref)
+		}
+
+		for j, imageCopy := range image.Copies {
+			if !strings.HasPrefix(imageCopy.Source, "/") {
+				return fmt.Errorf("source assets copy source %q from image %q must be an absolute path", imageCopy.Source, image.Ref)
+			}
+
+			destination := path.Clean(imageCopy.Destination)
+			if destination == "." || destination == ".." || path.IsAbs(destination) || strings.HasPrefix(destination, "../") {
+				return fmt.Errorf("source assets destination %q must be a relative path inside the source tree", imageCopy.Destination)
+			}
+
+			for _, other := range destinations {
+				if destination == other || strings.HasPrefix(destination, other+"/") || strings.HasPrefix(other, destination+"/") {
+					return fmt.Errorf("source assets destinations %q and %q overlap", destination, other)
+				}
+			}
+
+			destinations = append(destinations, destination)
+
+			assets.Images[i].Copies[j].Destination = destination
+		}
+	}
+
+	return nil
+}
+
+// destinations returns all destination paths in the declaration order.
+func (assets *SourceAssets) destinations() []string {
+	var out []string
+
+	for _, image := range assets.Images {
+		for _, imageCopy := range image.Copies {
+			out = append(out, imageCopy.Destination)
+		}
+	}
+
+	return out
+}
+
+// CompileDockerfile implements dockerfile.Compiler.
+//
+// It emits one stage per unique image and platform, and a scratch collector stage holding every
+// copy at its destination path. The base stage and the native fetch target both consume the
+// collector, so their contents are identical by construction.
+func (assets *SourceAssets) CompileDockerfile(output *dockerfile.Output) error {
+	sourceStages := map[string]string{}
+
+	for _, image := range assets.Images {
+		for _, imageCopy := range image.Copies {
+			key := image.Ref + "|" + imageCopy.Platform
+
+			if _, ok := sourceStages[key]; !ok {
+				stageName := fmt.Sprintf("%s-src-%d", SourceAssetsStage, len(sourceStages))
+				sourceStages[key] = stageName
+
+				stage := output.Stage(stageName).Description("source assets from " + image.Ref).From(image.Ref)
+
+				if imageCopy.Platform != "" {
+					stage.Platform(imageCopy.Platform)
+				}
+			}
+		}
+	}
+
+	collector := output.Stage(SourceAssetsStage).
+		Description("collects the source assets").
+		From("scratch")
+
+	for _, image := range assets.Images {
+		for _, imageCopy := range image.Copies {
+			collector.Step(step.Copy(imageCopy.Source, "/"+imageCopy.Destination).From(sourceStages[image.Ref+"|"+imageCopy.Platform]))
+		}
+	}
+
+	return nil
+}
+
+// SourceTreeBuild implements SourceTreeBuilder.
+func (assets *SourceAssets) SourceTreeBuild(stage *dockerfile.Stage) error {
+	stage.Step(step.Copy("/", "./").From(SourceAssetsStage))
+
+	return nil
+}
+
+// CompileMakefile implements makefile.Compiler.
+//
+// The build platform is pinned to a single constant one on purpose: the collector contents are
+// platform-independent, since every image stage pins its own platform explicitly, and a
+// multi-platform build would split the local export into per-platform subdirectories.
+func (assets *SourceAssets) CompileMakefile(output *makefile.Output) error {
+	quoted := xslices.Map(assets.destinations(), func(destination string) string { return "'" + destination + "'" })
+
+	output.Target("fetch-source-assets").
+		Description("Fetches the source assets into the source tree, for building natively outside docker.").
+		Script("rm -rf -- " + strings.Join(quoted, " ")).
+		Script("@$(MAKE) local-" + SourceAssetsStage + " DEST=./ PLATFORM=linux/amd64").
+		Phony()
+
+	return nil
+}
+
+// SkipAsMakefileDependency implements makefile.SkipAsMakefileDependency.
+func (assets *SourceAssets) SkipAsMakefileDependency() {}
+
+// CompileGitignore implements gitignore.Compiler.
+func (assets *SourceAssets) CompileGitignore(output *gitignore.Output) error {
+	output.IgnorePath(assets.destinations()...)
+
+	return nil
+}
+
+// CompileDockerignore implements dockerignore.Compiler.
+//
+// The destinations are excluded from the docker build context, so locally fetched copies never leak
+// into the container build, where the same files come from the image stages.
+func (assets *SourceAssets) CompileDockerignore(output *dockerignore.Output) error {
+	output.DenyLocalPath(assets.destinations()...)
+
+	return nil
+}
+
+// CompileRenovate implements renovate.Compiler.
+//
+// The image references get a custom manager, so they receive update PRs like any other pinned image.
+func (assets *SourceAssets) CompileRenovate(output *renovate.Output) error {
+	output.CustomManagers([]renovate.CustomManager{
+		{
+			CustomType:          "regex",
+			ManagerFilePatterns: []string{`/^\.kres\.yaml$/`},
+			MatchStrings:        []string{`ref:\s*["']?(?<depName>[^\s"']+):(?<currentValue>[A-Za-z0-9._-]+)["']?\s*$`},
+			DataSourceTemplate:  "docker",
+			VersioningTemplate:  "docker",
+		},
+	})
+
+	return nil
+}

--- a/internal/project/common/source_assets_test.go
+++ b/internal/project/common/source_assets_test.go
@@ -1,0 +1,211 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package common_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/kres/internal/output/dockerfile"
+	"github.com/siderolabs/kres/internal/output/dockerignore"
+	"github.com/siderolabs/kres/internal/output/gitignore"
+	"github.com/siderolabs/kres/internal/output/makefile"
+	"github.com/siderolabs/kres/internal/output/renovate"
+	"github.com/siderolabs/kres/internal/project/common"
+	"github.com/siderolabs/kres/internal/project/meta"
+)
+
+func sourceAssets(ref string, copies ...common.SourceAssetsCopy) *common.SourceAssets {
+	assets := common.NewSourceAssets(&meta.Options{})
+	assets.Images = []common.SourceAssetsImage{{Ref: ref, Copies: copies}}
+
+	return assets
+}
+
+func TestSourceAssetsValidation(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		assets   *common.SourceAssets
+		wantErr  string
+		wantDest string
+	}{
+		{
+			name:     "valid",
+			assets:   sourceAssets("ghcr.io/siderolabs/ipxe:v1.11.0", common.SourceAssetsCopy{Source: "/usr/libexec/", Destination: "internal/data"}),
+			wantDest: "internal/data",
+		},
+		{
+			name:     "normalized",
+			assets:   sourceAssets("ghcr.io/siderolabs/ipxe:v1.11.0", common.SourceAssetsCopy{Source: "/x", Destination: "./internal//data/"}),
+			wantDest: "internal/data",
+		},
+		{
+			name:    "empty ref",
+			assets:  sourceAssets("", common.SourceAssetsCopy{Source: "/x", Destination: "internal/data"}),
+			wantErr: "ref is empty",
+		},
+		{
+			name:    "no copies",
+			assets:  sourceAssets("ghcr.io/siderolabs/ipxe:v1.11.0"),
+			wantErr: "declares no copies",
+		},
+		{
+			name:    "relative source",
+			assets:  sourceAssets("ghcr.io/siderolabs/ipxe:v1.11.0", common.SourceAssetsCopy{Source: "usr/libexec/", Destination: "internal/data"}),
+			wantErr: "must be an absolute path",
+		},
+		{
+			name:    "absolute destination",
+			assets:  sourceAssets("ghcr.io/siderolabs/ipxe:v1.11.0", common.SourceAssetsCopy{Source: "/x", Destination: "/etc"}),
+			wantErr: "must be a relative path",
+		},
+		{
+			name:    "escaping destination",
+			assets:  sourceAssets("ghcr.io/siderolabs/ipxe:v1.11.0", common.SourceAssetsCopy{Source: "/x", Destination: "../outside"}),
+			wantErr: "must be a relative path",
+		},
+		{
+			name: "duplicate destination",
+			assets: sourceAssets(
+				"ghcr.io/siderolabs/ipxe:v1.11.0",
+				common.SourceAssetsCopy{Source: "/x", Destination: "internal/data"},
+				common.SourceAssetsCopy{Source: "/y", Destination: "internal/data"},
+			),
+			wantErr: "overlap",
+		},
+		{
+			name: "nested destination",
+			assets: sourceAssets(
+				"ghcr.io/siderolabs/ipxe:v1.11.0",
+				common.SourceAssetsCopy{Source: "/x", Destination: "internal/data"},
+				common.SourceAssetsCopy{Source: "/y", Destination: "internal/data/nested"},
+			),
+			wantErr: "overlap",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.assets.AfterLoad()
+
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantDest, tt.assets.Images[0].Copies[0].Destination)
+		})
+	}
+}
+
+func TestSourceAssetsOutputs(t *testing.T) {
+	assets := sourceAssets(
+		"ghcr.io/siderolabs/ipxe:v1.11.0",
+		common.SourceAssetsCopy{Platform: "linux/amd64", Source: "/usr/libexec/", Destination: "internal/data/amd64"},
+		common.SourceAssetsCopy{Platform: "linux/arm64", Source: "/usr/libexec/", Destination: "internal/data/arm64"},
+	)
+	require.NoError(t, assets.AfterLoad())
+
+	t.Run("makefile", func(t *testing.T) {
+		o := makefile.NewOutput()
+		require.NoError(t, assets.CompileMakefile(o))
+
+		var buf bytes.Buffer
+		require.NoError(t, o.GenerateFile("Makefile", &buf))
+
+		assert.Contains(t, buf.String(), "fetch-source-assets:")
+		assert.Contains(t, buf.String(), "rm -rf -- 'internal/data/amd64' 'internal/data/arm64'")
+		assert.Contains(t, buf.String(), "$(MAKE) local-source-assets DEST=./ PLATFORM=linux/amd64")
+	})
+
+	t.Run("gitignore", func(t *testing.T) {
+		o := gitignore.NewOutput()
+		require.NoError(t, assets.CompileGitignore(o))
+
+		var buf bytes.Buffer
+		require.NoError(t, o.GenerateFile(".gitignore", &buf))
+
+		assert.Contains(t, buf.String(), "internal/data/amd64")
+		assert.Contains(t, buf.String(), "internal/data/arm64")
+	})
+
+	t.Run("dockerignore", func(t *testing.T) {
+		o := dockerignore.NewOutput()
+		o.AllowLocalPath("internal")
+		require.NoError(t, assets.CompileDockerignore(o))
+
+		var buf bytes.Buffer
+		require.NoError(t, o.GenerateFile(".dockerignore", &buf))
+
+		content := buf.String()
+		assert.Contains(t, content, "!internal\n")
+		// the deny entries come after the allows, so they win
+		assert.Greater(t, bytes.Index(buf.Bytes(), []byte("internal/data/amd64")), bytes.Index(buf.Bytes(), []byte("!internal\n")))
+	})
+}
+
+func TestSourceAssetsRenovateRegex(t *testing.T) {
+	o := renovate.NewOutput()
+	o.Enable()
+
+	assets := sourceAssets("ghcr.io/siderolabs/ipxe:v1.11.0", common.SourceAssetsCopy{Source: "/x", Destination: "internal/data"})
+	require.NoError(t, assets.CompileRenovate(o))
+
+	var buf bytes.Buffer
+	require.NoError(t, o.GenerateFile(".github/renovate.json", &buf))
+
+	var config struct {
+		CustomManagers []struct {
+			MatchStrings []string `json:"matchStrings"`
+		} `json:"customManagers"`
+	}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &config))
+	require.Len(t, config.CustomManagers, 1)
+	require.Len(t, config.CustomManagers[0].MatchStrings, 1)
+
+	re := regexp.MustCompile(config.CustomManagers[0].MatchStrings[0])
+
+	for _, tt := range []struct {
+		line    string
+		wantDep string
+		wantVer string
+	}{
+		{"      ref: ghcr.io/siderolabs/ipxe:v1.11.0", "ghcr.io/siderolabs/ipxe", "v1.11.0"},
+		{`      ref: "ghcr.io/siderolabs/ipxe:v1.11.0"`, "ghcr.io/siderolabs/ipxe", "v1.11.0"},
+		{"      ref: registry.internal:5000/siderolabs/ipxe:v1.2.3", "registry.internal:5000/siderolabs/ipxe", "v1.2.3"},
+	} {
+		m := re.FindStringSubmatch(tt.line)
+		require.NotNil(t, m, tt.line)
+		assert.Equal(t, tt.wantDep, m[re.SubexpIndex("depName")], tt.line)
+		assert.Equal(t, tt.wantVer, m[re.SubexpIndex("currentValue")], tt.line)
+	}
+}
+
+func TestSourceAssetsStageDedup(t *testing.T) {
+	assets := common.NewSourceAssets(&meta.Options{})
+	assets.Images = []common.SourceAssetsImage{
+		{Ref: "ghcr.io/siderolabs/ipxe:v1.11.0", Copies: []common.SourceAssetsCopy{{Platform: "linux/amd64", Source: "/a", Destination: "internal/a"}}},
+		{Ref: "ghcr.io/siderolabs/ipxe:v1.11.0", Copies: []common.SourceAssetsCopy{{Platform: "linux/amd64", Source: "/b", Destination: "internal/b"}}},
+	}
+	require.NoError(t, assets.AfterLoad())
+
+	o := dockerfile.NewOutput()
+	o.Enable()
+	require.NoError(t, assets.CompileDockerfile(o))
+
+	var buf bytes.Buffer
+	require.NoError(t, o.GenerateFile("Dockerfile", &buf))
+
+	// the identical image and platform across separate entries collapse into one source stage
+	assert.Equal(t, 1, strings.Count(buf.String(), "AS source-assets-src-"))
+	assert.Contains(t, buf.String(), "COPY --from=source-assets-src-0 /a /internal/a")
+	assert.Contains(t, buf.String(), "COPY --from=source-assets-src-0 /b /internal/b")
+}

--- a/internal/project/common/toolchain.go
+++ b/internal/project/common/toolchain.go
@@ -10,3 +10,9 @@ import "github.com/siderolabs/kres/internal/output/dockerfile"
 type ToolchainBuilder interface {
 	ToolchainBuild(*dockerfile.Stage) error
 }
+
+// SourceTreeBuilder is implemented by nodes which inject content into the source tree of the
+// golang base stage, before any Go package loading happens there.
+type SourceTreeBuilder interface {
+	SourceTreeBuild(*dockerfile.Stage) error
+}

--- a/internal/project/golang/toolchain.go
+++ b/internal/project/golang/toolchain.go
@@ -281,6 +281,14 @@ func (toolchain *Toolchain) CompileDockerfile(output *dockerfile.Output) error {
 		base.Step(step.Copy("./"+file, "./"+file))
 	}
 
+	// inject the source assets into the source tree. They must be present before any Go loading
+	// below, since the sources may reference them via go:embed.
+	for _, input := range dag.GatherMatchingInputs(toolchain, dag.Implements[common.SourceTreeBuilder]()) {
+		if err := input.(common.SourceTreeBuilder).SourceTreeBuild(base); err != nil { //nolint:forcetypeassert,errcheck
+			return err
+		}
+	}
+
 	base.Step(
 		step.Script(`go list -mod=readonly all >/dev/null`).
 			MountCache(filepath.Join(toolchain.meta.GoPath, "pkg"), toolchain.meta.GitHubRepository),

--- a/internal/project/golang/toolchain_test.go
+++ b/internal/project/golang/toolchain_test.go
@@ -5,14 +5,19 @@
 package golang_test
 
 import (
+	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/siderolabs/kres/internal/output/dockerfile"
 	"github.com/siderolabs/kres/internal/output/ghworkflow"
 	"github.com/siderolabs/kres/internal/output/makefile"
+	"github.com/siderolabs/kres/internal/project/common"
 	"github.com/siderolabs/kres/internal/project/golang"
+	"github.com/siderolabs/kres/internal/project/meta"
 )
 
 func TestToolchainInterfaces(t *testing.T) {
@@ -20,4 +25,44 @@ func TestToolchainInterfaces(t *testing.T) {
 	assert.Implements(t, (*makefile.Compiler)(nil), new(golang.Toolchain))
 	assert.Implements(t, (*ghworkflow.Compiler)(nil), new(golang.Toolchain))
 	assert.Implements(t, (*makefile.SkipAsMakefileDependency)(nil), new(golang.Toolchain))
+}
+
+func TestToolchainSourceAssets(t *testing.T) {
+	assets := common.NewSourceAssets(&meta.Options{})
+	assets.Images = []common.SourceAssetsImage{{
+		Ref: "ghcr.io/siderolabs/ipxe:v1.11.0",
+		Copies: []common.SourceAssetsCopy{
+			{Platform: "linux/amd64", Source: "/usr/libexec/", Destination: "internal/ipxe/data/amd64"},
+			{Platform: "linux/arm64", Source: "/usr/libexec/", Destination: "internal/ipxe/data/arm64"},
+		},
+	}}
+	require.NoError(t, assets.AfterLoad())
+
+	toolchain := golang.NewToolchain(&meta.Options{
+		GoContainerVersion: "1.26",
+		Directories:        []string{"internal"},
+		GoRootDirectories:  []string{"."},
+		GoDirectories:      []string{"internal"},
+	})
+	toolchain.AddInput(assets)
+
+	output := dockerfile.NewOutput()
+
+	require.NoError(t, assets.CompileDockerfile(output))
+	require.NoError(t, toolchain.CompileDockerfile(output))
+
+	var buf bytes.Buffer
+
+	require.NoError(t, output.GenerateFile("Dockerfile", &buf))
+
+	generated := buf.String()
+
+	assert.Contains(t, generated, "ghcr.io/siderolabs/ipxe:v1.11.0 AS source-assets-src-0")
+	assert.Contains(t, generated, "ghcr.io/siderolabs/ipxe:v1.11.0 AS source-assets-src-1")
+	assert.Contains(t, generated, "COPY --from=source-assets-src-0 /usr/libexec/ /internal/ipxe/data/amd64")
+
+	// the collector contents land in the source tree of base, before any Go package loading
+	copyLine := "COPY --from=source-assets / ./"
+	assert.Contains(t, generated, copyLine)
+	assert.Less(t, strings.Index(generated, copyLine), strings.Index(generated, "go list -mod=readonly"))
 }


### PR DESCRIPTION
Projects can now declare source assets: files pulled from pinned container images into the source tree of the build, without being committed to the repository, e.g. binaries referenced by go:embed directives.

Example:

```yaml
kind: common.SourceAssets
spec:
  images:
    - ref: ghcr.io/siderolabs/ipxe:v1.11.0
      copies:
        - platform: linux/amd64
          source: /usr/libexec/
          destination: internal/ipxe/data/amd64
```

The declaration generates everything derived from it: the image stages and a collector stage in the Dockerfile, the copy into the source tree of the base stage so lint, tests, and builds all see the files, the git and docker ignore rules for the destinations, a fetch-source-assets make target which materializes the same collector stage locally for native builds outside docker, and a renovate manager so the image references receive update PRs.

Invalid configurations fail generation: an empty image reference, a relative source path, a destination escaping the source tree, and overlapping destinations.


