### PR TITLE
chore: bump node container version

### DIFF
--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -94,7 +94,7 @@ const (
 	// As a rule of thumb, we bump only to the versions promoted to be LTS (even [not odd] major versions get promoted after a while, always check).
 	//
 	// renovate: datasource=docker versioning=docker depName=node
-	NodeContainerImageVersion = "24.18.0-alpine"
+	NodeContainerImageVersion = "24.18.1-alpine"
 	// PkgsVersion is the version of pkgs.
 	// renovate: datasource=github-tags depName=siderolabs/pkgs
 	PkgsVersion = "v1.13.0"


### PR DESCRIPTION
Bump node container version