### PR TITLE
refactor: renovate more often

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,7 +6,7 @@
         ":dependencyDashboard",
         ":gitSignOff",
         ":semanticCommitScopeDisabled",
-        "schedule:earlyMondays"
+        "schedule:nonOfficeHours"
     ],
     "customManagers": [
         {

--- a/internal/output/renovate/renovate.go
+++ b/internal/output/renovate/renovate.go
@@ -41,7 +41,7 @@ func NewOutput() *Output {
 			":dependencyDashboard",
 			":gitSignOff",
 			":semanticCommitScopeDisabled",
-			"schedule:earlyMondays",
+			"schedule:nonOfficeHours",
 		},
 		PRHeader:           "Update Request | Renovate Bot",
 		SeparateMajorMinor: false,


### PR DESCRIPTION
Instead of only on Mondays, run daily in non-office hours. Let's update dependency dashboards more often. 

https://docs.renovatebot.com/presets-schedule/#schedulenonofficehours