### PR TITLE
fix: make update-checksums work with build args

### DIFF
--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -12,7 +12,7 @@ const (
 
 	// BldrImageVersion is the version of bldr image.
 	// renovate: datasource=github-releases depName=siderolabs/bldr
-	BldrImageVersion = "v0.6.1"
+	BldrImageVersion = "v0.6.2"
 
 	// CheckOutActionVersion is the version of checkout github action.
 	// renovate: datasource=github-tags depName=actions/checkout

--- a/internal/project/pkgfile/build.go
+++ b/internal/project/pkgfile/build.go
@@ -157,7 +157,7 @@ func (pkgfile *Build) CompileMakefile(output *makefile.Output) error {
 		Depends("$(ARTIFACTS)/bldr").
 		Phony().
 		Description("Updates the checksums in the Pkgfile/vars.yaml based on the changed version variables.").
-		Script(`@git diff -U0 | $(ARTIFACTS)/bldr update`)
+		Script(`@git diff -U0 | $(ARTIFACTS)/bldr update $(BUILD_ARGS)`)
 
 	output.VariableGroup(makefile.VariableGroupTargets).
 		Variable(makefile.RecursiveVariable("TARGETS", strings.Join(pkgfile.Targets, "\n")))


### PR DESCRIPTION
This updates the bldr to the fixed version and also modifies the Makefile to pass the build args.